### PR TITLE
Secrets Storage, Retrieval and Parameter Store

### DIFF
--- a/.chalice/policy.json
+++ b/.chalice/policy.json
@@ -18,6 +18,14 @@
         "clouddirectory:*"
       ],
       "Resource": "*"
+    },
+    {
+      "Action": [
+        "secretsmanager:GetSecretValue"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+      ]
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ npm-debug.log
 /.chalice/deployed.json
 /.chalice/policy-*.json
 /README.rst
+
+# fusillade specific
+/oauth2_config.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - AWS_DEFAULT_OUTPUT=json
 
 before_install:
+  - source environment
   - pip install --quiet coverage flake8 pyyaml
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 SHELL=/bin/bash
-STAGE=dev
-export API_HOST=auth.${STAGE}.data.humancellatlas.org
 
 tests:=$(wildcard tests/test_*.py)
 
@@ -29,12 +27,15 @@ install: docs
 	python setup.py bdist_wheel
 	pip install --upgrade dist/*.whl
 
+set_oauth2_config:
+	cat ./oauth2_config.json | ./scripts/set_secret.py --secret-name oauth2_config
+
 deploy:
 	git clean -df chalicelib vendor
 	shopt -s nullglob; for wheel in vendor.in/*/*.whl; do unzip -q -o -d vendor $$wheel; done
 	cat fusillade-api.yml | envsubst '$$API_HOST' > chalicelib/swagger.yml
-	./build_chalice_config.sh $(STAGE)
-	chalice deploy --no-autogen-policy --stage $(STAGE) --api-gateway-stage $(STAGE)
+	./build_chalice_config.sh $(FUS_DEPLOYMENT_STAGE)
+	chalice deploy --no-autogen-policy --stage $(FUS_DEPLOYMENT_STAGE) --api-gateway-stage $(FUS_DEPLOYMENT_STAGE)
 
 .PHONY: test release docs
 

--- a/Readme.md
+++ b/Readme.md
@@ -45,10 +45,15 @@ To do this, your application should define an access control model consisting of
 
 Installing and configuring Fusillade
 ------------------------------------
- 
+Create `oauth2_config.json` with the OIDC providers you'd like to use to 
+authenticate users. This file is uploaded to AWS secrets manager using `make set_oauth2_config`. Use 
+[`oauth2_config.example.json`](../blob/master/oauth2_config.example.json) for help.
+    
+
 - pip install -r ./requirements-dev
 - brew install jq
 - brew install pandoc
+- brew install moreutils
 - brew install gettext
 - brew link --force gettext 
 

--- a/app.py
+++ b/app.py
@@ -39,7 +39,8 @@ def serve_swagger_definition():
     return swagger_defn
 
 
-oauth2_config = json.loads(secretsmanager.get_secret_value(SecretId="fusillade.oauth2_config")["SecretString"])
+oauth2_config = json.loads(secretsmanager.get_secret_value(
+    SecretId=f"{os.environ['FUS_SECRETS_STORE']}/{os.environ['FUS_DEPLOYMENT_STAGE']}/oauth2_config")["SecretString"])
 
 
 @functools.lru_cache(maxsize=32)

--- a/environment
+++ b/environment
@@ -1,0 +1,35 @@
+# HCA Fusillade environment variables
+#
+# Source this file in your bash shell using "source environment".
+#
+# The environment variables set in this file are appropriate for the
+# HCA Fusillade development environment. Individual environment variable
+# values are overridden when deployed, based on the deployment stage.
+
+# Resolve the location of this file and set FUS_HOME to the root
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
+export FUS_HOME="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+
+EXPORT_ENV_VARS_TO_LAMBDA_ARRAY=(
+    FUS_DEPLOYMENT_STAGE
+    FUS_SECRETS_STORE
+    OPENID_PROVIDER
+)
+
+set -a
+EXPORT_ENV_VARS_TO_LAMBDA=${EXPORT_ENV_VARS_TO_LAMBDA_ARRAY[*]}
+FUS_PARAMETER_STORE=dcp/fusillade
+FUS_DEPLOYMENT_STAGE=dev
+FUS_SECRETS_STORE=dcp/fusillade
+OPENID_PROVIDER=humancellatlas.auth0.com
+
+set +a
+
+if [[ -f "${FUS_HOME}/environment.local" ]]; then
+    source "${FUS_HOME}/environment.local"
+fi
+
+set -a
+API_HOST=auth.${FUS_DEPLOYMENT_STAGE}.data.humancellatlas.org
+set +a

--- a/oauth2_config.example.json
+++ b/oauth2_config.example.json
@@ -1,0 +1,12 @@
+{
+  "accounts.google.com": {
+    "client_id": "replace_with_account_into.apps.googleusercontent.com",
+    "client_secret": "super_secret",
+    "redirect_uri": "https://auth.example.com/cb"
+  },
+  "example.auth0.com": {
+    "client_id": "the_client_id",
+    "client_secret": "super_secret_2",
+    "redirect_uri": "https://auth.example2.com/cb"
+  }
+}

--- a/scripts/populate_lambda_ssm_parameters.py
+++ b/scripts/populate_lambda_ssm_parameters.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+"""
+This script compiles $EXPORT_ENV_VARS_TO_LAMBDA into a json document and
+uploads it into AWS Systems Manager Parameter Store under the key
+`dcp/fusillade/{FUS_DEPLOYMENT_STAGE}/environment`, optionally updating
+the environment of every deployed lambda.
+
+Individual environment variables may also be set and unset across both SSM and
+deployed lambdas.
+"""
+import os
+import sys
+import json
+import boto3
+import argparse
+
+ssm_client = boto3.client("ssm")
+lambda_client = boto3.client("lambda")
+
+def get_local_lambda_environment():
+    env = dict()
+    for name in os.environ['EXPORT_ENV_VARS_TO_LAMBDA'].split():
+        try:
+            env[name] = os.environ[name]
+        except KeyError:
+            print(f"Warning: {name} not defined")
+    return env
+
+def get_ssm_lambda_environment():
+    parms = ssm_client.get_parameter(
+        Name=f"/{os.environ['FUS_PARAMETER_STORE']}/{os.environ['FUS_DEPLOYMENT_STAGE']}/environment"
+    )['Parameter']['Value']
+    return json.loads(parms)
+
+def set_ssm_lambda_environment(parms: dict):
+    ssm_client.put_parameter(
+        Name=f"/dcp/fusillade/{os.environ['FUS_DEPLOYMENT_STAGE']}/environment",
+        Value=json.dumps(parms),
+        Type="String",
+        Overwrite=True,
+    )
+
+def get_deployed_lambda_environment(name):
+    return lambda_client.get_function_configuration(FunctionName=name)['Environment']['Variables']
+
+def set_deployed_lambda_environment(name, env: dict):
+    lambda_client.update_function_configuration(
+        FunctionName=name,
+        Environment={
+            'Variables': env
+        }
+    )
+
+def get_deployed_lambda():
+    name = f"fusillade-{os.environ['FUS_DEPLOYMENT_STAGE']}"
+    try:
+        resp = lambda_client.get_function(FunctionName=name)
+        yield name
+    except lambda_client.exceptions.ResourceNotFoundException:
+        print(f"{name} not deployed, or does not deploy a Lambda function")
+
+def get_admin_user_emails():
+    secret_base = "{}/{}/".format(
+        os.environ['FUS_SECRETS_STORE'],
+        os.environ['FUS_DEPLOYMENT_STAGE'])
+
+    gcp_secret_id = secret_base + os.environ['GOOGLE_APPLICATION_CREDENTIALS_SECRETS_NAME']
+    admin_secret_id = secret_base + os.environ['ADMIN_USER_EMAILS_SECRETS_NAME']
+    resp = boto3.client("secretsmanager").get_secret_value(SecretId=gcp_secret_id)
+    gcp_service_account_email = json.loads(resp['SecretString'])['client_email']
+    resp = boto3.client("secretsmanager").get_secret_value(SecretId=admin_secret_id)
+    admin_user_emails = [email for email in resp['SecretString'].split(',') if email.strip()]
+    admin_user_emails.append(gcp_service_account_email)
+    return ",".join(admin_user_emails)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--update-deployed-lambdas",
+        default=False,
+        action="store_true",
+        help="update the environment of all deployed lambdas"
+    )
+    parser.add_argument("-p", "--print",
+        default=False,
+        action="store_true",
+        help="Display the current environemnt stored in SSM"
+    )
+    parser.add_argument("--set",
+        default=None,
+        help="Set a single environment variable in SSM parameters and all deployed lambdas"
+    )
+    parser.add_argument("--unset",
+        default=None,
+        help="Remove a single environment variable in SSM parameters and all deployed lambdas"
+    )
+    args = parser.parse_args()
+
+    if args.print:
+        ssm_env = get_ssm_lambda_environment()
+        for name, val in ssm_env.items():
+            print(f"{name}={val}")
+    elif args.set is not None:
+        name, val = args.set.split("=")
+        ssm_env = get_ssm_lambda_environment()
+        ssm_env[name] = val
+        set_ssm_lambda_environment(ssm_env)
+        lambda_name = get_deployed_lambda()
+        lambda_env = get_deployed_lambda_environment(lambda_name)
+        lambda_env[name] = val
+        set_deployed_lambda_environment(lambda_name, lambda_env)
+    elif args.unset is not None:
+        name = args.unset
+        ssm_env = get_ssm_lambda_environment()
+        try:
+            del ssm_env[name]
+        except KeyError:
+            pass
+        set_ssm_lambda_environment(ssm_env)
+        lambda_name = get_deployed_lambda()
+        lambda_env = get_deployed_lambda_environment(lambda_name)
+        try:
+            del lambda_env[name]
+        except KeyError:
+            pass
+        set_deployed_lambda_environment(lambda_name, lambda_env)
+    else:
+        lambda_env = get_local_lambda_environment()
+        # lambda_env['ADMIN_USER_EMAILS'] = get_admin_user_emails()
+        set_ssm_lambda_environment(lambda_env)
+        if args.update_deployed_lambdas:
+            lambda_name = get_deployed_lambda()
+            set_deployed_lambda_environment(lambda_name, lambda_env)

--- a/scripts/set_secret.py
+++ b/scripts/set_secret.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+import os
+import sys
+import boto3
+import select
+import argparse
+
+
+SM = boto3.client('secretsmanager')
+stage = os.environ['FUS_DEPLOYMENT_STAGE']
+secrets_store = os.environ['FUS_SECRETS_STORE']
+
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--secret-name", required=True)
+parser.add_argument("--dry-run", required=False, action='store_true')
+args = parser.parse_args()
+
+
+secret_id = f'{secrets_store}/{stage}/{args.secret_name}'
+
+
+if not select.select([sys.stdin, ], [], [], 0.0)[0]:
+    print(f"No data in stdin, exiting without setting {secret_id}")
+    sys.exit()
+val = sys.stdin.read()
+
+
+print("setting", secret_id)
+
+
+try:
+    resp = SM.get_secret_value(
+        SecretId=secret_id
+    )
+except SM.exceptions.ResourceNotFoundException:
+    if args.dry_run:
+        print('Resource Not Found: Creating {}'.format(secret_id))
+    else:
+        resp = SM.create_secret(
+            Name=secret_id,
+            SecretString=val
+        )
+else:
+    if args.dry_run:
+        print('Resource Found: Updating {}'.format(secret_id))
+    else:
+        resp = SM.update_secret(
+            SecretId=secret_id,
+            SecretString=val
+        )


### PR DESCRIPTION
- chalice app now retrieve the secret from the location specified by FUS_SECRETS_STORE and FUS_DEPLOYMENT_STAGE
- modifying policy to add get-secret permission

- moved environment variable out of makefile and into environment.
- environment must be sourced before make deploy
- environment.local can be set to replace environment variable set in environment

- lambda environment variables are retrieved from parameter store
- added script to upload lambda environment variables to AWS parameter store. Variables specified in EXPORT_ENV_VAR_TO_LAMBDA will be added to AWS parameter store when script/populate_lambda_ssm_paramters.py is called

- adding moreutils to setup requirements

- Adding make recipe set_oauth2_config. This set the secret {FUS_SECRETS_STORE}/{FUS_DEPLOYMENT_STAGE}/oauth2_config in AWS secrets manager. Added script set_secret to facilitate uploading the secret, and added example files for users to reference when setting up.