### PR TITLE
Fixing evaluate policy

### DIFF
--- a/app.py
+++ b/app.py
@@ -229,7 +229,8 @@ def evaluate_policy():
                 'ContextKeyType': 'string'
             }
         ]
-    )
+    )['EvaluationResults'][0]['EvalDecision']
+    result = True if result == 'allowed' else False
     return dict(principal=principal, action=action, resource=resource, result=result)
 
 

--- a/app.py
+++ b/app.py
@@ -218,14 +218,18 @@ def evaluate_policy():
     action = json_body["action"]
     resource = json_body["resource"]
     user = User(directory, principal)
-    user.lookup_policies()
-    result = iam.simulate_custom_policy(PolicyInputList=user.lookup_policies(),
-                                        ActionNames=[action],
-                                        ResourceArns=[resource])
-    # "arn:hca:dss:*:*:subscriptions/{}/*".format(username)]))
-
-    # result["EvaluationResults"][0]["EvalDecision"]]
-    del result["ResponseMetadata"]
+    result = iam.simulate_custom_policy(
+        PolicyInputList=user.lookup_policies(),
+        ActionNames=[action],
+        ResourceArns=[resource],
+        ContextEntries=[
+            {
+                'ContextKeyName': 'fus:user_email',
+                'ContextKeyValues': [principal],
+                'ContextKeyType': 'string'
+            }
+        ]
+    )
     return dict(principal=principal, action=action, resource=resource, result=result)
 
 

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -547,7 +547,9 @@ class CloudDirectory:
         # parse the policies from the responses
         policies = []
         for response in responses:
-            policies.append(response['SuccessfulResponse']['GetObjectAttributes']['Attributes'][0]['Value'])
+            policy = response['SuccessfulResponse']['GetObjectAttributes']['Attributes'][0]['Value']['StringValue']
+            if policy != '{}':
+                policies.append(policy)
         return policies
 
     def get_object_information(self, obj_ref: str) -> typing.Dict[str, typing.Any]:
@@ -626,7 +628,7 @@ class CloudNode:
         self.cd.batch_write(operations)
 
     def lookup_policies(self) -> typing.List[str]:
-        return [policy['StringValue'] for policy in self.cd.lookup_policy(self.object_reference)]
+        return self.cd.lookup_policy(self.object_reference)
 
     @property
     def name(self):

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -547,9 +547,8 @@ class CloudDirectory:
         # parse the policies from the responses
         policies = []
         for response in responses:
-            policy = response['SuccessfulResponse']['GetObjectAttributes']['Attributes'][0]['Value']['StringValue']
-            if policy != '{}':
-                policies.append(policy)
+            policies.append(response['SuccessfulResponse']['GetObjectAttributes']['Attributes'][0]['Value']
+                            ['StringValue'])
         return policies
 
     def get_object_information(self, obj_ref: str) -> typing.Dict[str, typing.Any]:

--- a/policies/default_user_policy.json
+++ b/policies/default_user_policy.json
@@ -1,1 +1,13 @@
-{}
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "user_example",
+      "Effect": "Allow",
+      "Action": [
+        "resource:GetSomething"
+      ],
+       "Resource": "arn:hca:resource:*:*:path/*"
+    }
+  ]
+}

--- a/tests/infra/server.py
+++ b/tests/infra/server.py
@@ -18,10 +18,10 @@ class ChaliceTestHarness:
         item = item.upper()
         return functools.partial(self.request, method=item)
 
-    def request(self, path, headers={}, body={}, method="GET"):
+    def request(self, path, headers={}, data='', method="GET"):
         resp_obj = requests.Response()
         try:
-            response = self._gateway.handle_request(method, path, headers, body)
+            response = self._gateway.handle_request(method, path, headers, data)
         except LocalGatewayException as error:
             resp_obj.status_code = error.CODE
             resp_obj.headers = error.headers
@@ -30,6 +30,6 @@ class ChaliceTestHarness:
             resp_obj.status_code = response['statusCode']
             resp_obj.headers = response['headers']
             resp_obj.body = response['body']
-        resp_obj.headers['Content-Length'] = str(len(body))
+        resp_obj.headers['Content-Length'] = str(len(data))
         return resp_obj
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -139,7 +139,7 @@ class TestApi(unittest.TestCase):
                 },
                 'response': {
                     'code': 200,
-                    'result': ['implicitDeny']
+                    'result': False
                 }
             },
             {
@@ -150,7 +150,7 @@ class TestApi(unittest.TestCase):
                 },
                 'response': {
                     'code': 200,
-                    'result': ['allowed']
+                    'result': True
                 }
             }
         ]
@@ -160,8 +160,7 @@ class TestApi(unittest.TestCase):
                 headers={'Content-Type': "application/json"}
                 resp = self.app.post('/policies/evaluate', headers=headers, data=data)
                 self.assertEqual(test['response']['code'], resp.status_code)  # TODO fix
-                result = [i['EvalDecision'] for i in json.loads(resp.body)['result']['EvaluationResults']]
-                self.assertListEqual(test['response']['result'], result)
+                self.assertEqual(test['response']['result'], json.loads(resp.body)['result'])
 
     def test_put_user(self):
         pass

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -106,15 +106,15 @@ class TestApi(unittest.TestCase):
 
     def test_serve_jwks_json(self):
         resp = self.app.get('/.well-known/jwks.json')
-        self.assertEqual(resp.status_code, 500)  # TODO fix
+        self.assertEqual(resp.status_code, 200)  # TODO fix
 
     def test_revoke(self):
         resp = self.app.get('/oauth/revoke')
-        self.assertEqual(resp.status_code, 500)  # TODO fix
+        self.assertEqual(resp.status_code, 404)  # TODO fix
 
     def test_userinfo(self):
         resp = self.app.get('/userinfo')
-        self.assertEqual(resp.status_code, 500)  # TODO fix
+        self.assertEqual(resp.status_code, 401)  # TODO fix
 
     def test_serve_oauth_token(self):
         resp = self.app.post('/oauth/token')


### PR DESCRIPTION
- policies are retrieved from user
- the users name is used as a context variable within the policy
- added a positive and negative test cases based on the users default policy.
- if a policy is empty do not return it when looking up policies
- Updating user test cases to reflect empty policies being returned
- Changing the name of body to data in test/infra/server.py to make integration testing easier in the future