### PR TITLE
User policy not set by default

### DIFF
--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -678,16 +678,16 @@ class CloudNode:
         self._set_statement(statement)
 
     def _set_statement(self, statement: str):
-        params = [
-            UpdateObjectParams('IAMPolicy',
-                               'Statement',
-                               ValueTypes.StringValue,
-                               statement,
-                               UpdateActions.CREATE_OR_UPDATE)
-        ]
         if not self.policy:
             self.create_policy(statement)
         else:
+            params = [
+                UpdateObjectParams('IAMPolicy',
+                                   'Statement',
+                                   ValueTypes.StringValue,
+                                   statement,
+                                   UpdateActions.CREATE_OR_UPDATE)
+            ]
             self.cd.update_object_attribute(self.policy, params)
         self._statement = None
 

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -21,6 +21,8 @@ project_arn = "arn:aws:clouddirectory:us-east-1:861229788715:"  # TODO move to c
 cd_client = aws_clients.clouddirectory
 
 proj_path = os.path.dirname(__file__)
+
+# TODO make all configurable
 directory_schema_path = os.path.join(proj_path, 'directory_schema.json')
 default_user_policy_path = os.path.join(proj_path, '..', 'policies', 'default_user_policy.json')
 default_group_policy_path = os.path.join(proj_path, '..', 'policies', 'default_group_policy.json')
@@ -239,26 +241,24 @@ class CloudDirectory:
     def _make_ref(i):
         return '$' + i
 
-    def create_object(self, link_name: str, statement: str, obj_type: str, **kwargs) -> typing.Tuple[str, str]:
-        operations = list()
+    def create_object(self, link_name: str, obj_type: str, **kwargs) -> str:
+        """
+        Create an object and store in cloud directory.
+        """
         object_attribute_list = self._get_object_attribute_list(facet=obj_type, **kwargs)
         parent_path = self.get_obj_type_path(obj_type)
-        operations.append(self.batch_create_object(parent_path, link_name, obj_type, object_attribute_list))
+        cd_client.create_object(DirectoryArn=self._dir_arn,
+                                SchemaFacets=[
+                                    {
+                                        'SchemaArn': self.schema,
+                                        'FacetName': obj_type
+                                    },
+                                ],
+                                ObjectAttributeList=object_attribute_list,
+                                ParentReference=dict(Selector=parent_path),
+                                LinkName=link_name)
         object_ref = parent_path + link_name
-
-        object_attribute_list = self.get_policy_attribute_list(obj_type, statement)
-        policy_link_name = f"{link_name}_policy"
-        parent_path = self.get_obj_type_path('policy')
-        operations.append(self.batch_create_object(parent_path,
-                                                   policy_link_name,
-                                                   'IAMPolicy',
-                                                   object_attribute_list))
-        policy_ref = parent_path + policy_link_name
-
-        operations.append(self.batch_attach_policy(policy_ref, object_ref))
-        self.batch_write(operations)  # TODO check that everything passed
-
-        return object_ref, policy_ref
+        return object_ref
 
     def get_object_attributes(self, obj_ref: str, facet: str, attributes: typing.List[str]) -> typing.Dict[str, str]:
         """
@@ -630,9 +630,34 @@ class CloudNode:
     def policy(self):
         if not self._policy:
             policies = [i for i in self.cd.list_object_policies(self.object_reference)]
-            assert len(policies) == 1
-            self._policy = policies[0]
+            if not policies:
+                return None
+            elif len(policies) > 1:
+                raise ValueError("Node has multiple policies attached")
+            else:
+                self._policy = policies[0]
         return self._policy
+
+    def create_policy(self, statement: str, ) -> str:
+        """
+        Create a policy object and attach it to the CloudNode
+        :param statement: Json string that follow AWS IAM Policy Grammar.
+          https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_grammar.html
+        :return:
+        """
+        operations = list()
+        object_attribute_list = self.cd.get_policy_attribute_list(self._object_type, statement)
+        policy_link_name = f"{self._path_name}_{self._object_type}_IAMPolicy"
+        parent_path = self.cd.get_obj_type_path('policy')
+        operations.append(self.cd.batch_create_object(parent_path,
+                                                      policy_link_name,
+                                                      'IAMPolicy',
+                                                      object_attribute_list))
+        policy_ref = parent_path + policy_link_name
+
+        operations.append(self.cd.batch_attach_policy(policy_ref, self.object_reference))
+        self.cd.batch_write(operations)
+        return policy_ref
 
     @property
     def statement(self):
@@ -640,7 +665,7 @@ class CloudNode:
         Policy statements follow AWS IAM Policy Grammer. See for grammar details
         https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_grammar.html
         """
-        if not self._statement:
+        if not self._statement and self.policy:
             self._statement = self.cd.get_object_attributes(self.policy,
                                                             'IAMPolicy',
                                                             ['Statement'])['Attributes'][0]['Value'].popitem()[1]
@@ -650,6 +675,9 @@ class CloudNode:
     @statement.setter
     def statement(self, statement: str):
         self._verify_statement(statement)
+        self._set_statement(statement)
+
+    def _set_statement(self, statement: str):
         params = [
             UpdateObjectParams('IAMPolicy',
                                'Statement',
@@ -657,7 +685,10 @@ class CloudNode:
                                statement,
                                UpdateActions.CREATE_OR_UPDATE)
         ]
-        self.cd.update_object_attribute(self.policy, params)
+        if not self.policy:
+            self.create_policy(statement)
+        else:
+            self.cd.update_object_attribute(self.policy, params)
         self._statement = None
 
     def _set_attributes(self, attributes: typing.List[str]):
@@ -749,14 +780,12 @@ class User(CloudNode):
         self._status = None
 
     def provision_user(self, statement: typing.Optional[str] = None) -> None:
-        if not statement:
-            statement = get_json_file(default_user_policy_path)
-        self._verify_statement(statement)
         self.cd.create_object(self._path_name,
-                              statement,
                               'User',
                               name=self.name,
                               status='Enabled')
+        if statement:  # TODO make using user default configurable
+            self.statement = statement
 
     @property
     def groups(self):
@@ -813,10 +842,9 @@ class Group(CloudNode):
         if not statement:
             statement = get_json_file(default_group_policy_path)
         cls._verify_statement(statement)
-        object_ref, policy_ref = cloud_directory.create_object(quote(name), statement, 'Group', name=name)
+        cloud_directory.create_object(quote(name), 'Group', name=name)
         new_node = cls(cloud_directory, name)
-        new_node._statement = statement
-        new_node._policy = policy_ref
+        new_node._set_statement(statement)
         return new_node
 
     def get_users(self) -> typing.Iterator[typing.Tuple[str, str]]:
@@ -878,8 +906,7 @@ class Role(CloudNode):
         if not statement:
             statement = get_json_file(default_role_path)
         cls._verify_statement(statement)
-        object_ref, policy_ref = cloud_directory.create_object(quote(name), statement, 'Role', name=name)
+        cloud_directory.create_object(quote(name), 'Role', name=name)
         new_node = cls(cloud_directory, name)
-        new_node._statement = statement
-        new_node._policy = policy_ref
+        new_node._set_statement(statement)
         return new_node

--- a/fusillade/config.py
+++ b/fusillade/config.py
@@ -12,6 +12,7 @@ class Config:
     def get_admin_emails(cls):
         if not cls._admin_emails:
             cls._admin_emails = [admin.strip() for admin in os.environ['FUS_ADMIN_EMAILS'].split(',') if admin.strip()]
+            assert cls._admin_emails, "initial administrator must be specified."
         return cls._admin_emails
 
     @classmethod

--- a/fusillade/config.py
+++ b/fusillade/config.py
@@ -12,7 +12,7 @@ class Config:
     def get_admin_emails(cls):
         if not cls._admin_emails:
             cls._admin_emails = [admin.strip() for admin in os.environ['FUS_ADMIN_EMAILS'].split(',') if admin.strip()]
-            assert cls._admin_emails, "initial administrator must be specified."
+            assert cls._admin_emails, "Initial administrator must be specified. Set FUS_ADMIN_EMAILS."
         return cls._admin_emails
 
     @classmethod

--- a/tests/test_clouddirectory.py
+++ b/tests/test_clouddirectory.py
@@ -1,7 +1,7 @@
 import unittest
 import os, sys
 from urllib.parse import quote
-
+from unittest import mock
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
@@ -9,6 +9,8 @@ from tests.common import random_hex_string
 import fusillade
 from fusillade.clouddirectory import cd_client, cleanup_directory, cleanup_schema, publish_schema, create_directory, \
     CloudDirectory
+
+admin_email = "test_email1@domain.com,test_email2@domain.com, test_email3@domain.com "
 
 
 class TestCloudDirectory(unittest.TestCase):
@@ -46,6 +48,7 @@ class TestCloudDirectory(unittest.TestCase):
         with self.subTest("error returned when deleting a nonexistent schema."):
             self.assertRaises(cd_client.exceptions.ResourceNotFoundException, cleanup_schema, schema_arn_2)
 
+    @mock.patch.dict(os.environ, FUS_ADMIN_EMAILS=admin_email)
     def test_structure(self):
         """Check that cloud directory is setup for fusillade"""
         schema_name = "authz"
@@ -68,11 +71,11 @@ class TestCloudDirectory(unittest.TestCase):
                 resp = directory.get_object_information(role)
                 self.assertTrue(resp['ObjectIdentifier'])
 
-            for admin in fusillade.Config.get_admin_emails():
-                with self.subTest(f"Admin user {admin} created when the directory is created"):
-                    user = '/Users/' + quote(admin)
-                    resp = directory.get_object_information(user)
-                    self.assertTrue(resp['ObjectIdentifier'])
+        for admin in fusillade.Config.get_admin_emails():
+            with self.subTest(f"Admin user {admin} created when the directory is created"):
+                user = '/Users/' + quote(admin)
+                resp = directory.get_object_information(user)
+                self.assertTrue(resp['ObjectIdentifier'])
 
 
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -33,10 +33,10 @@ class TestUser(unittest.TestCase):
         with self.subTest("new user is created when instantiating User class with an new user name "):
             name = "test_get_user_policy@test.com"
             user = User(self.directory, name)
-            self.assertEqual(user.lookup_policies(), [self.default_policy])
+            self.assertEqual(user.lookup_policies(), [])
         with self.subTest("an existing users info is retrieved when instantiating User class for an existing user"):
             user = User(self.directory, name)
-            self.assertEqual(user.lookup_policies(), [self.default_policy])
+            self.assertEqual(user.lookup_policies(), [])
 
     def test_get_groups(self):
         name = "test_get_groups@test.com"
@@ -63,7 +63,7 @@ class TestUser(unittest.TestCase):
 
         with self.subTest("A user inherits the groups policies when joining a group"):
             policies = set(user.lookup_policies())
-            expected_policies = set([i[1] for i in test_groups] + [self.default_policy])
+            expected_policies = set([i[1] for i in test_groups])
             self.assertEqual(policies, expected_policies)
 
     def test_remove_groups(self):
@@ -90,11 +90,16 @@ class TestUser(unittest.TestCase):
     def test_set_policy(self):
         name = "test_set_policy@test.com"
         user = User(self.directory, name)
-        with self.subTest("The initial user policy is default_policy, when the user is first created"):
-            self.assertEqual(user.statement, self.default_policy)
-            self.assertIn(self.default_policy, user.lookup_policies())
+        with self.subTest("The initial user policy is None, when the user is first created"):
+            self.assertEqual(user.statement, None)
 
         statement = create_test_statement(f"UserPolicySomethingElse")
+        user.statement = statement
+        with self.subTest("The user policy is set when statement setter is used."):
+            self.assertEqual(user.statement, statement)
+            self.assertIn(statement, user.lookup_policies())
+
+        statement = create_test_statement(f"UserPolicySomethingElse2")
         user.statement = statement
         with self.subTest("The user policy changes when set_policy is used."):
             self.assertEqual(user.statement, statement)
@@ -148,6 +153,7 @@ class TestUser(unittest.TestCase):
                user.add_roles(["ghost_role"])
                self.assertTrue(ex.response['Error']['Message'].endswith("/ Roles / ghost_role\\' does not exist.'"))
 
+        user.statement = self.default_policy
         with self.subTest("A user inherits a roles policies when a role is added to a user."):
             self.assertListEqual(sorted(user.lookup_policies()), sorted([user.statement, role_statement]))
 
@@ -189,6 +195,7 @@ class TestUser(unittest.TestCase):
 
         user.add_roles(role_names)
         user.add_groups(group_names)
+        user.statement = self.default_policy
 
         self.assertListEqual(sorted(user.roles), ['default_user'] + role_names)
         self.assertEqual(user.groups, group_names)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -24,6 +24,13 @@ class TestUser(unittest.TestCase):
     def tearDown(self):
         self.directory.clear()
 
+    def test_user_statement(self):
+        name = "user_statement@test.com"
+        user = User(self.directory, name, local=True)
+        user.provision_user(self.default_policy)
+        test_user = User(self.directory, name)
+        self.assertEqual(test_user.statement, self.default_policy)
+
     def test_get_attributes(self):
         name = "test_get_attributes@test.com"
         user = User(self.directory, name)


### PR DESCRIPTION

* Creating an object does not automatically create and attach a policy. The statement setter will create a policy and attach it to cloud node if none exists. This will prevent an excessive number of dummies policies from being created whenever a user is created.
* A user attached policy is not created by default since most user will not have a policy directly attached. 

