### PR TITLE
using typed links to connect users, roles, and groups

### DIFF
--- a/fusillade/__init__.py
+++ b/fusillade/__init__.py
@@ -19,7 +19,7 @@ def get_directory():
     except FusilladeException:
         from .clouddirectory import publish_schema, create_directory
         schema_name = Config.get_schema_name()
-        schema_arn = publish_schema(schema_name, version="0.1")  # TODO make version an environment variable
+        schema_arn = publish_schema(schema_name, version="0.2")  # TODO make version an environment variable
         directory = create_directory(directory_name, schema_arn)
     return directory
 

--- a/fusillade/directory_schema.json
+++ b/fusillade/directory_schema.json
@@ -1,12 +1,28 @@
 {
   "sourceSchemaArn": "",
   "facets": {
-    "Group": {
+    "BasicFacet": {
       "facetAttributes": {
         "name": {
           "attributeDefinition": {
             "attributeType": "STRING",
             "isImmutable": true,
+            "attributeRules": {
+              "nameLength": {
+                "parameters": {
+                  "min": "1",
+                  "max": "128"
+                },
+                "ruleType": "STRING_LENGTH"
+              }
+            }
+          },
+          "requiredBehavior": "REQUIRED_ALWAYS"
+        },
+        "obj_type": {
+          "attributeDefinition": {
+            "attributeType": "STRING",
+            "isImmutable": false,
             "attributeRules": {
               "nameLength": {
                 "parameters": {
@@ -22,12 +38,28 @@
       },
       "objectType": "NODE"
     },
-    "User": {
+    "UserFacet": {
       "facetAttributes": {
         "name": {
           "attributeDefinition": {
             "attributeType": "STRING",
             "isImmutable": true,
+            "attributeRules": {
+              "nameLength": {
+                "parameters": {
+                  "min": "1",
+                  "max": "128"
+                },
+                "ruleType": "STRING_LENGTH"
+              }
+            }
+          },
+          "requiredBehavior": "REQUIRED_ALWAYS"
+        },
+        "obj_type": {
+          "attributeDefinition": {
+            "attributeType": "STRING",
+            "isImmutable": false,
             "attributeRules": {
               "nameLength": {
                 "parameters": {
@@ -59,27 +91,6 @@
       },
       "objectType": "LEAF_NODE"
     },
-    "Role": {
-      "facetAttributes": {
-        "name": {
-          "attributeDefinition": {
-            "attributeType": "STRING",
-            "isImmutable": true,
-            "attributeRules": {
-              "nameLength": {
-                "parameters": {
-                  "min": "1",
-                  "max": "64"
-                },
-                "ruleType": "STRING_LENGTH"
-              }
-            }
-          },
-          "requiredBehavior": "REQUIRED_ALWAYS"
-        }
-      },
-      "objectType": "NODE"
-    },
     "IAMPolicy": {
       "facetAttributes": {
         "Statement": {
@@ -94,5 +105,48 @@
       "objectType": "POLICY"
     }
   },
-  "typedLinkFacets": {}
+  "typedLinkFacets": {
+    "association": {
+      "facetAttributes": {
+        "parent_type": {
+            "attributeDefinition": {
+                "attributeType": "STRING",
+                "isImmutable": false,
+                "attributeRules": {}
+            },
+            "requiredBehavior": "REQUIRED_ALWAYS"
+        },
+        "child_type": {
+          "attributeDefinition": {
+              "attributeType": "STRING",
+              "isImmutable": false,
+              "attributeRules": {}
+          },
+          "requiredBehavior": "REQUIRED_ALWAYS"
+        }
+      },
+      "identityAttributeOrder": [
+        "parent_type",
+        "child_type"
+      ]
+    },
+    "ownership": {
+      "facetAttributes": {
+        "owner": {
+            "attributeDefinition": {
+                "attributeType": "BOOLEAN",
+                "isImmutable": false,
+                "defaultValue": {
+                  "booleanValue": true
+                },
+                "attributeRules": {}
+            },
+            "requiredBehavior": "REQUIRED_ALWAYS"
+        }
+      },
+      "identityAttributeOrder": [
+          "owner"
+      ]
+    }
+  }
 }

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -73,6 +73,7 @@ class TestGroup(unittest.TestCase):
             group.add_users([user])
             actual_users = [i[1] for i in group.get_users()]
             self.assertEqual(len(actual_users), 1)
+            self.assertEqual(User(self.directory,object_ref=actual_users[0]).name, user.name)
 
         with self.subTest("Multiple users are added to the group when multiple users are passed to add_users"):
             group = Group.create(self.directory, "test2")
@@ -90,6 +91,13 @@ class TestGroup(unittest.TestCase):
             actual_users = [i[1] for i in group.get_users()]
             self.assertEqual(len(actual_users), 3)
 
+        with self.subTest("Error returned when adding a user that does not exist"):
+            group = Group.create(self.directory, "test4")
+            user = User(self.directory, "ghost_user@nowhere.com", local=True)
+            try:
+                group.add_users([user])
+            except cd_client.exceptions.BatchWriteException:
+                pass
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fix removes the dependency on CloudNode._link_format to store information about the type of relationship between object. There is a hard limit of 64 characters for a link name and when the combined name of the entities exceed this limit, cloud directory throws an error. Now the link name is a hash of the parent and child using SHA1 which produces a 40 byte hash. Links only need to be unique between two objects so the risk of collision is extremely low.

An additional typed_link is added between two objects. Typed links allows us to store the relationship between the two objects without  relying on the link name. This type of link does not participate in the policy lookup, but can be used to filter different types of objects linked.