### PR TITLE
Remove local variable from User and Group

### DIFF
--- a/fusillade/api/groups/__init__.py
+++ b/fusillade/api/groups/__init__.py
@@ -15,12 +15,12 @@ def get_groups():
 
 
 def get_group(group_id):
-    group = Group(directory, group_id, local=True)
+    group = Group(directory, group_id)
     return make_response(jsonify(name=group.name, policy=group.statement), 200)
 
 
 def put_group_policy(group_id):
-    group = Group(directory, group_id, local=True)
+    group = Group(directory, group_id)
     group.statement = request.json['policy']
     return make_response("", 200)
 
@@ -30,12 +30,12 @@ def get_group_users(group_id):
 
 
 def get_groups_roles(group_id):
-    group = Group(directory, group_id, local=True)
+    group = Group(directory, group_id)
     return make_response(jsonify(roles=group.roles), 200)
 
 
 def put_groups_roles(group_id):
-    group = Group(directory, group_id, local=True)
+    group = Group(directory, group_id)
     action = request.args['action']
     if action == 'add':
         group.add_roles(request.json['roles'])

--- a/fusillade/api/users/__init__.py
+++ b/fusillade/api/users/__init__.py
@@ -4,7 +4,7 @@ from fusillade import User, directory
 
 def put_new_user():
     json_body = request.json
-    user = User(directory, json_body['username'], local=True)
+    user = User(directory, json_body['username'])
     user.provision_user(statement=json_body.get('policy'))
     user.add_roles(json_body.get('roles', []))
     user.add_groups(json_body.get('groups', []))
@@ -12,12 +12,12 @@ def put_new_user():
 
 
 def get_user(user_id):
-    user = User(directory, user_id, local=True)
+    user = User(directory, user_id)
     return make_response(jsonify(name=user.name, status=user.status, policy=user.statement), 200)
 
 
 def put_user(user_id):
-    user = User(directory, user_id, local=True)
+    user = User(directory, user_id)
     new_status = request.args['status']
     if new_status == 'enabled':
         user.enable()
@@ -31,18 +31,18 @@ def put_user(user_id):
 
 
 def put_user_policy(user_id):
-    user = User(directory, user_id, local=True)
+    user = User(directory, user_id)
     user.statement = request.json['policy']
     return make_response('', 200)
 
 
 def get_users_groups(user_id):
-    user = User(directory, user_id, local=True)
+    user = User(directory, user_id)
     return make_response(jsonify(groups=user.groups), 200)
 
 
 def put_users_groups(user_id):
-    user = User(directory, user_id, local=True)
+    user = User(directory, user_id)
     action = request.args['action']
     if action == 'add':
         user.add_groups(request.json['groups'])
@@ -52,12 +52,12 @@ def put_users_groups(user_id):
 
 
 def get_users_roles(user_id):
-    user = User(directory, user_id, local=True)
+    user = User(directory, user_id)
     return make_response(jsonify(roles=user.roles), 200)
 
 
 def put_users_roles(user_id):
-    user = User(directory, user_id, local=True)
+    user = User(directory, user_id)
     action = request.args['action']
     if action == 'add':
         user.add_roles(request.json['roles'])

--- a/tests/common.py
+++ b/tests/common.py
@@ -18,7 +18,7 @@ def random_hex_string(length=8):
     return ''.join([random.choice(string.hexdigits) for i in range(length)])
 
 
-def new_test_directory(directory_name=None):
+def new_test_directory(directory_name=None) -> CloudDirectory:
     directory_name = directory_name if directory_name else "test_dir_" + random_hex_string()
     schema_arn = publish_schema(schema_name, 'T' + random_hex_string())
     directory = create_directory(directory_name, schema_arn)

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -26,9 +26,6 @@ class TestGroup(unittest.TestCase):
         self.directory.clear()
 
     def test_create_group(self):
-        with self.subTest("an error is returned when the group has not been created."):
-            self.assertRaises(cd_client.exceptions.ResourceNotFoundException, Group, self.directory, 'not_created')
-
         with self.subTest("an error is returned when creating a group with an invalid statement."):
             with self.assertRaises(FusilladeException):
                 group = Group.create(self.directory, "new_group1", "does things")
@@ -66,10 +63,10 @@ class TestGroup(unittest.TestCase):
 
     def test_users(self):
         emails = ["test@test.com", "why@not.com", "hello@world.com"]
-        users = [User(self.directory, email) for email in emails]
+        users = [User.provision_user(self.directory, email) for email in emails]
         with self.subTest("A user is added to the group when add_users is called"):
             group = Group.create(self.directory, "test")
-            user = User(self.directory, "another@place.com")
+            user = User.provision_user(self.directory, "another@place.com")
             group.add_users([user])
             actual_users = [i[1] for i in group.get_users()]
             self.assertEqual(len(actual_users), 1)
@@ -93,7 +90,7 @@ class TestGroup(unittest.TestCase):
 
         with self.subTest("Error returned when adding a user that does not exist"):
             group = Group.create(self.directory, "test4")
-            user = User(self.directory, "ghost_user@nowhere.com", local=True)
+            user = User(self.directory, "ghost_user@nowhere.com")
             try:
                 group.add_users([user])
             except cd_client.exceptions.BatchWriteException:

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -43,7 +43,7 @@ class TestUser(unittest.TestCase):
                           "lookup_policy is called for a new user."):
             self.assertEqual(user.lookup_policies(), [self.default_user_role_policy])
         with self.subTest("error is returned when provision_user is called for an existing user"):
-            user.provision_user(self.directory, name)
+            self.assertRaises(FusilladeException, user.provision_user, self.directory, name)
         with self.subTest("an existing users info is retrieved when instantiating User class for an existing user"):
             user = User(self.directory, name)
             self.assertEqual(user.lookup_policies(), [self.default_user_role_policy])

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -27,21 +27,23 @@ class TestUser(unittest.TestCase):
 
     def test_user_statement(self):
         name = "user_statement@test.com"
-        user = User(self.directory, name, local=True)
-        user.provision_user(self.default_policy)
+        User.provision_user(self.directory, name, statement=self.default_policy)
         test_user = User(self.directory, name)
         self.assertEqual(test_user.statement, self.default_policy)
 
     def test_get_attributes(self):
         name = "test_get_attributes@test.com"
-        user = User(self.directory, name)
+        user = User.provision_user(self.directory, name)
         self.assertEqual(user.get_attributes(['name'])['name'], name)
 
     def test_get_user_policy(self):
-        with self.subTest("new user is created when instantiating User class with an new user name "):
-            name = "test_get_user_policy@test.com"
-            user = User(self.directory, name)
+        name = "test_get_user_policy@test.com"
+        user = User(self.directory, name)
+        with self.subTest("new user is automatically provisioned on demand with default settings when "
+                          "lookup_policy is called for a new user."):
             self.assertEqual(user.lookup_policies(), [self.default_user_role_policy])
+        with self.subTest("error is returned when provision_user is called for an existing user"):
+            user.provision_user(self.directory, name)
         with self.subTest("an existing users info is retrieved when instantiating User class for an existing user"):
             user = User(self.directory, name)
             self.assertEqual(user.lookup_policies(), [self.default_user_role_policy])
@@ -51,7 +53,7 @@ class TestUser(unittest.TestCase):
         test_groups = [(f"group_{i}", create_test_statement(f"GroupPolicy{i}")) for i in range(5)]
         groups = [Group.create(self.directory, *i) for i in test_groups]
 
-        user = User(self.directory, name)
+        user = User.provision_user(self.directory, name)
         with self.subTest("A user is in no groups when user is first created."):
             self.assertEqual(len(user.groups), 0)
 
@@ -79,7 +81,7 @@ class TestUser(unittest.TestCase):
         name = "test_remove_group@test.com"
         test_groups = [(f"group_{i}", create_test_statement(f"GroupPolicy{i}")) for i in range(5)]
         groups = [Group.create(self.directory, *i).name for i in test_groups]
-        user = User(self.directory, name)
+        user = User.provision_user(self.directory, name)
         with self.subTest("A user is removed from a group when remove_group is called for a group the user belongs "
                           "to."):
             user.add_groups(groups)
@@ -98,7 +100,7 @@ class TestUser(unittest.TestCase):
 
     def test_set_policy(self):
         name = "test_set_policy@test.com"
-        user = User(self.directory, name)
+        user = User.provision_user(self.directory, name)
         with self.subTest("The initial user policy is None, when the user is first created"):
             self.assertEqual(user.statement, None)
 
@@ -121,7 +123,7 @@ class TestUser(unittest.TestCase):
 
     def test_status(self):
         name = "test_sete_policy@test.com"
-        user = User(self.directory, name)
+        user = User.provision_user(self.directory, name)
 
         with self.subTest("A user's status is enabled when provisioned."):
             self.assertEqual(user.status, 'Enabled')
@@ -140,7 +142,7 @@ class TestUser(unittest.TestCase):
         role_names = sorted(role_names)
         role_statements = sorted(role_statements)
 
-        user = User(self.directory, name)
+        user = User.provision_user(self.directory, name)
         user_role_names = [Role(self.directory,None,role).name for role in user.roles]
         with self.subTest("a user has the default_user roles when created."):
             self.assertEqual(user_role_names, ['default_user'])
@@ -194,7 +196,7 @@ class TestUser(unittest.TestCase):
         A user inherits policies from groups and roles when the user is apart of a group and assigned a role.
         """
         name = "test_set_policy@test.com"
-        user = User(self.directory, name)
+        user = User.provision_user(self.directory, name)
         test_groups = [(f"group_{i}", create_test_statement(f"GroupPolicy{i}")) for i in range(5)]
         [Group.create(self.directory, *i) for i in test_groups]
         group_names, group_statements = zip(*test_groups)
@@ -221,7 +223,7 @@ class TestUser(unittest.TestCase):
     @unittest.skip("TODO: unfinished and low priority")
     def test_remove_user(self):
         name = "test_get_user_policy@test.com"
-        user = User(self.directory, name)
+        user = User.provision_user(self.directory, name)
         self.assertEqual(len(self.directory.lookup_policy(user.reference)), 1)
         user.remove_user()
         self.directory.lookup_policy(user.reference)


### PR DESCRIPTION
- remove local variable from User and Group
- changing User._set_attributes to User._get_attributes to be less confusing
- remove unused imports
- provision_user is a class method and returns a User initialized in Clouddirectory
- added default_roles and default_groups to User class.