### PR TITLE
always use a hash of the name to create the link name. This prevents …

### DIFF
--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -796,7 +796,7 @@ class CloudNode:
         batch_attach_typed_link = self.cd.batch_attach_typed_link
         operations = []
         for link in links:
-            parent_ref = parent_path + link  # TODO use f-string
+            parent_ref = f"{parent_path}{self.hash_name(link)}"
             operations.append(
                 batch_attach_object(
                     parent_ref,
@@ -830,7 +830,7 @@ class CloudNode:
         make_typed_link_specifier = self.cd.make_typed_link_specifier
         operations = []
         for link in links:
-            parent_ref = parent_path + link
+            parent_ref = f"{parent_path}{self.hash_name(link)}"
             operations.append(
                 batch_detach_object(
                     parent_ref,

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -489,7 +489,7 @@ class CloudDirectory:
         for _, obj_ref in self.list_object_children('/group/'):
             self.delete_object(obj_ref)
         for name, obj_ref in self.list_object_children('/role/'):
-            if name not in ["admin", "default_user"]:
+            if name not in [CloudNode.hash_name("admin"), CloudNode.hash_name("default_user")]:
                 self.delete_object(obj_ref)
 
     def delete_policy(self, policy_ref: str) -> None:
@@ -757,7 +757,7 @@ class CloudNode:
 
     @staticmethod
     def hash_name(name):
-        return hashlib.sha256(bytes(name, "utf-8")).hexdigest()
+        return hashlib.sha1(bytes(name, "utf-8")).hexdigest()
 
     @staticmethod
     def _get_link_name(parent_path: str, child_path: str):

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -868,7 +868,7 @@ class CloudNode:
                 self._policy = policies[0]
         return self._policy
 
-    def create_policy(self, statement: str, ) -> str:
+    def create_policy(self, statement: str) -> str:
         """
         Create a policy object and attach it to the CloudNode
         :param statement: Json string that follow AWS IAM Policy Grammar.
@@ -877,7 +877,7 @@ class CloudNode:
         """
         operations = list()
         object_attribute_list = self.cd.get_policy_attribute_list(self._facet, statement)
-        policy_link_name = f"{self._path_name}_{self._object_type}_IAMPolicy"
+        policy_link_name = self.get_policy_name('IAMPolicy')
         parent_path = self.cd.get_obj_type_path('policy')
         operations.append(self.cd.batch_create_object(parent_path,
                                                       policy_link_name,
@@ -888,6 +888,9 @@ class CloudNode:
         operations.append(self.cd.batch_attach_policy(policy_ref, self.object_ref))
         self.cd.batch_write(operations)
         return policy_ref
+
+    def get_policy_name(self, policy_type):
+        return self.hash_name(f"{self._path_name}{self._object_type}{policy_type}")
 
     @property
     def statement(self):

--- a/tests/test_clouddirectory.py
+++ b/tests/test_clouddirectory.py
@@ -8,7 +8,7 @@ sys.path.insert(0, pkg_root)  # noqa
 from tests.common import random_hex_string
 import fusillade
 from fusillade.clouddirectory import cd_client, cleanup_directory, cleanup_schema, publish_schema, create_directory, \
-    CloudDirectory
+    CloudDirectory, CloudNode
 
 admin_email = "test_email1@domain.com,test_email2@domain.com, test_email3@domain.com "
 
@@ -65,7 +65,7 @@ class TestCloudDirectory(unittest.TestCase):
                 resp = directory.get_object_information(f'/{folder}')
                 self.assertTrue(resp['ObjectIdentifier'])
 
-        roles = ['/role/admin', '/role/default_user']
+        roles = [f"/role/{CloudNode.hash_name(name)}" for name in ['admin', 'default_user']]
         for role in roles:
             with self.subTest(f"{role} roles is created when directory is created"):
                 resp = directory.get_object_information(role)
@@ -73,7 +73,7 @@ class TestCloudDirectory(unittest.TestCase):
 
         for admin in fusillade.Config.get_admin_emails():
             with self.subTest(f"Admin user {admin} created when the directory is created"):
-                user = '/user/' + quote(admin)
+                user = '/user/' + CloudNode.hash_name(admin)
                 resp = directory.get_object_information(user)
                 self.assertTrue(resp['ObjectIdentifier'])
 


### PR DESCRIPTION
…us from hitting the 64 character link name limit for long emails.