### PR TITLE
Use the test service account in aws secret store when FUS_DEPLOYMENT_…

### DIFF
--- a/fusillade/__init__.py
+++ b/fusillade/__init__.py
@@ -15,13 +15,14 @@ service config:
 def get_directory():
     directory_name = Config.get_directory_name()
     try:
-        directory = CloudDirectory.from_name(directory_name)
+        _directory = CloudDirectory.from_name(directory_name)
     except FusilladeException:
         from .clouddirectory import publish_schema, create_directory
         schema_name = Config.get_schema_name()
         schema_arn = publish_schema(schema_name, version="0.2")  # TODO make version an environment variable
-        directory = create_directory(directory_name, schema_arn)
-    return directory
+        admins = Config.get_admin_emails()
+        _directory = create_directory(directory_name, schema_arn, admins)
+    return _directory
 
 
 directory = get_directory()

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -16,7 +16,6 @@ from collections import namedtuple
 from enum import Enum, auto
 
 from fusillade.errors import FusilladeException
-from fusillade.config import Config
 
 project_arn = "arn:aws:clouddirectory:us-east-1:861229788715:"  # TODO move to config.py
 cd_client = aws_clients.clouddirectory
@@ -75,12 +74,13 @@ def publish_schema(name: str, version: str) -> str:
     return pub_schema_arn
 
 
-def create_directory(name: str, schema: str) -> 'CloudDirectory':
+def create_directory(name: str, schema: str, admins: typing.List[str]) -> 'CloudDirectory':
     """
     Retrieve the fusillade cloud directory or do a one time setup of cloud directory to be used with fusillade.
 
     :param name:
     :param schema:
+    :param admins: a list of admins to create
     :return:
     """
     try:
@@ -101,7 +101,7 @@ def create_directory(name: str, schema: str) -> 'CloudDirectory':
         Role.create(directory, "admin", statement=get_json_file(default_admin_role_path))
 
         # create admins
-        for admin in Config.get_admin_emails():
+        for admin in admins:
             User.provision_user(directory, admin, roles=['admin'])
     return directory
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,41 +1,41 @@
+import functools
+import logging
+import random
+import string
 import time
-import jwt
-from fusillade import Config
-
-# These GCP credentials point to a valid service account that is not associated with HCA. They can be used to test code
-# paths that require Google authentication, but then require further permissions validation once they reach data-store.
-GCP_CREDENTIALS = {
-    'type': 'service_account',
-    'project_id': 'cool-project-188401',
-    'private_key_id': 'e9db2f96adb67a91b1e10f8014159ca13eaf16ee',
-    'private_key': '-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDF2ywdURP1louy\nR8nHVjdI+s/CiQ5IKH8uzMbehDdBAt1hXQRvLOWle+f4sN5CTfrG/TcZ1dSLShvu\nt71YrFCjqvgw7EsXp/S7MidtrGyHweWQELJ4mnZTSC1iYcVvJXWGdBfgJl8Qgt27\nztrRVzBvJJiuTk1zAviDGbqZRIBNkCn6NOIPjrfZ8KHx7j9nyamPie3V7Kzx+cgo\nkxiiQ36lvhfAdD/U3aV/RdRYxpZPKHgCcX1eZkFGKWR1HrjiTsvJ8fgtgwTB5fux\nw4MbUwwELsSEWbGIXr5ZTZeeYa7kfAwDlL9yam/XaD3gAv0dBsxhW8ElBGqXQLgB\nfBz8A2vjAgMBAAECggEASIW7t8s+O6jA78oshepuPUvh13aRS5W8eJUK2Akyj5vT\nNZr4wx971ZqDPr7l2PvoTgQGrGuaiqvRbUDgIJ6YuEU00AnsxHEF3Y/Wr/ahmWlT\nEels4ZQMhx5PtF4OFl1upKftEHZAJjcxu2NpBY6l7DdH16xP6zZNjRBjO0bGmKb4\nBJlvcNPcQGptuBRo0pbYGNIo614ML5pzeHf95TDFaUw1GMyHG+oVuLZK/os1RmT0\n3tNLKMBPSwhDsT3o9xuWWi2uKw3Z1thwmLgXJj4kX2uqepFnYO1PZ+wJYbTEoHxi\n+LWRpWcTzIH+6cRGrZzoa+HHa+5npCvfc96SC1uYsQKBgQDpJZBf7du1dL8zwx5K\niaOnImtQhc35iVG7nFTi5wc5RNxYio6Cx7fTr8E/kvYjqknYxMFdTf8hmmFQnfXz\nfSbfiBzKtZWp6P7cdtcsR5EtY9tvjagwK7awJPbJyJXKlQeiDRsVTS4JB/XGTAAF\nLg4/Y1uGVNGP5Z29bwBWTkD1PQKBgQDZQAx0jUx6ft50UNleGsourWDBBMPuHFik\nyE+ej7SfpEJAZ29HAsbJBVXHeCUF3NZRRwWNFWrPfttWYyx/sCyz8tfsY74oF3om\nh0iAXT0kXqLP5i0rJORpoKPyMwAFltLnXIqQDAkLOri+rvtwonrn0rtUZJZPGoxe\nbhnBPpc3nwKBgDtvUw3Rcjgg6flFHXy899ZMpPTjF24svoRIRy+M27+SuWVs9QWL\n6mXxoR8W1N6ks6yqA+1IS+kCFRrbGe8XkYhch5J5lgy5k/cZ6KKmH/FlSnR2tVCK\nZEklMzCfjOgW89ow4x2cDkdJGzOQ/lRTuFgaeSOWjdHUJFE9ceWOj2q1AoGBAJKp\nhX8NgMrVaTIW/pdj+IgIbeAAapENu94KiI2fsC1xw3QdH+dNfYtpuZ3+gufxTRHz\no1C6W7AWkNZB/2F4OsWEtLYWI+KG7uShwZU+3K734Gv/lRCiSDzywJsaSPJ8/oZI\nWBakuVpGW0AHeyFv3w8vmV2AxmRCpO5+344wxf87AoGBAIr614y4YEHfXO/TUiwb\nLau6KYp5FYtCHHWv8RujV9mRoOnNUIGVYDLk6jJVkeZWJUwVjWBetYkRVdlbvDwq\nXuL5G+lNa3GKQnqgdCDtzPyuv77x33/XcbkmRiAfUb1ePtn3ufIBXcjTXwkGLh0i\ng/hD0R3CD4EtI95IWxnTU8BF\n-----END PRIVATE KEY-----\n',  # noqa
-    'client_email': 'project-viewer@cool-project-188401.iam.gserviceaccount.com',
-    'client_id': '112492781067934988519',
-    'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
-    'token_uri': 'https://accounts.google.com/o/oauth2/token',
-    'auth_provider_x509_cert_url': 'https://www.googleapis.com/oauth2/v1/certs',
-    'client_x509_cert_url': 'https://www.googleapis.com/robot/v1/metadata/x509/project-viewer%40cool-project-188401.iam.gserviceaccount.com',  # noqa
-}
-
-def get_service_jwt(service_credentials, email=True, audience=None):
-    iat = time.time()
-    exp = iat + 3600
-    payload = {'iss': service_credentials["client_email"],
-               'sub': service_credentials["client_email"],
-               'aud': audience or Config.audience,
-               'iat': iat,
-               'exp': exp,
-               'scope': ['email', 'openid', 'offline_access']
-               }
-    if email:
-        payload['email'] = service_credentials["client_email"]
-    additional_headers = {'kid': service_credentials["private_key_id"]}
-    signed_jwt = jwt.encode(payload, service_credentials["private_key"], headers=additional_headers,
-                            algorithm='RS256').decode()
-    return signed_jwt
 
 
-def get_auth_header(email=True):
-    info = GCP_CREDENTIALS
-    token = get_service_jwt(info, email=email)
-    return {"Authorization": f"Bearer {token}"}
+schema_name = 'authz'
+random.seed(time.time())
+logger = logging.getLogger()
+
+
+def random_hex_string(length=8):
+    return ''.join([random.choice(string.hexdigits) for i in range(length)])
+
+
+def eventually(timeout: float, interval: float, errors: set = {AssertionError}):
+    """
+    @eventually runs a test until all assertions are satisfied or a timeout is reached.
+    :param timeout: time until the test fails
+    :param interval: time between attempts of the test
+    :param errors: the exceptions to catch and retry on
+    :return: the result of the function or a raised assertion error
+    """
+    def decorate(func):
+        @functools.wraps(func)
+        def call(*args, **kwargs):
+            timeout_time = time.time() + timeout
+            error_tuple = tuple(errors)
+            while True:
+                try:
+                    return func(*args, **kwargs)
+                except error_tuple as e:
+                    if time.time() >= timeout_time:
+                        raise
+                    logger.debug("Error in %s: %s. Retrying after %s s...", func, e, interval)
+                    time.sleep(interval)
+
+        return call
+
+    return decorate

--- a/tests/common.py
+++ b/tests/common.py
@@ -38,7 +38,7 @@ def new_test_directory(directory_name=None) -> CloudDirectory:
     directory_name = directory_name if directory_name else "test_dir_" + random_hex_string()
     schema_arn = publish_schema(schema_name, 'T' + random_hex_string())
     directory = create_directory(directory_name, schema_arn, [service_accounts['admin']['client_email']])
-    return directory
+    return directory, schema_arn
 
 
 def get_service_jwt(service_credentials, email=True, audience=None):

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,28 +1,18 @@
-import functools
 import json
-import random
-import string
+import os
 import time
-import logging
+
+import jwt
+from dcplib.aws import clients
+from tests import schema_name, random_hex_string
+from fusillade.config import Config
+from fusillade.clouddirectory import publish_schema, create_directory, CloudDirectory
 
 
-from fusillade.clouddirectory import publish_schema, create_directory, cleanup_directory, CloudDirectory
-
-random.seed(time.time())
-
-logger = logging.getLogger()
-schema_name = 'authz'
-
-
-def random_hex_string(length=8):
-    return ''.join([random.choice(string.hexdigits) for i in range(length)])
-
-
-def new_test_directory(directory_name=None) -> CloudDirectory:
-    directory_name = directory_name if directory_name else "test_dir_" + random_hex_string()
-    schema_arn = publish_schema(schema_name, 'T' + random_hex_string())
-    directory = create_directory(directory_name, schema_arn)
-    return directory, schema_arn
+sm = clients.secretsmanager
+service_accounts = json.loads(
+    sm.get_secret_value(SecretId=f"{os.environ['FUS_SECRETS_STORE']}/test_service_accounts")["SecretString"]
+)
 
 
 def create_test_statement(name: str):
@@ -44,28 +34,33 @@ def create_test_statement(name: str):
     return json.dumps(statement)
 
 
-def eventually(timeout: float, interval: float, errors: set = {AssertionError}):
-    """
-    @eventually runs a test until all assertions are satisfied or a timeout is reached.
-    :param timeout: time until the test fails
-    :param interval: time between attempts of the test
-    :param errors: the exceptions to catch and retry on
-    :return: the result of the function or a raised assertion error
-    """
-    def decorate(func):
-        @functools.wraps(func)
-        def call(*args, **kwargs):
-            timeout_time = time.time() + timeout
-            error_tuple = tuple(errors)
-            while True:
-                try:
-                    return func(*args, **kwargs)
-                except error_tuple as e:
-                    if time.time() >= timeout_time:
-                        raise
-                    logger.debug("Error in %s: %s. Retrying after %s s...", func, e, interval)
-                    time.sleep(interval)
+def new_test_directory(directory_name=None) -> CloudDirectory:
+    directory_name = directory_name if directory_name else "test_dir_" + random_hex_string()
+    schema_arn = publish_schema(schema_name, 'T' + random_hex_string())
+    directory = create_directory(directory_name, schema_arn, [service_accounts['admin']['client_email']])
+    return directory
 
-        return call
 
-    return decorate
+def get_service_jwt(service_credentials, email=True, audience=None):
+    iat = time.time()
+    exp = iat + 3600
+    payload = {'iss': service_credentials["client_email"],
+               'sub': service_credentials["client_email"],
+               'aud': audience or Config.audience,
+               'iat': iat,
+               'exp': exp,
+               'scope': ['email', 'openid', 'offline_access']
+               }
+    if email:
+        payload['email'] = service_credentials["client_email"]
+    additional_headers = {'kid': service_credentials["private_key_id"]}
+    signed_jwt = jwt.encode(payload, service_credentials["private_key"], headers=additional_headers,
+                            algorithm='RS256').decode()
+    return signed_jwt
+
+
+def get_auth_header(service_credentials: dict, email=True):
+    info = service_credentials
+    token = get_service_jwt(info, email=email)
+    return {"Authorization": f"Bearer {token}"}
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -95,8 +95,8 @@ class TestAuthentication(unittest.TestCase):
             self.assertEqual(redirect_url.args["response_type"], 'code')
             query_params["openid_provider"] = "humancellatlas.auth0.com"
             self.assertDictEqual(json.loads(base64.b64decode(redirect_url.args["state"])), query_params)
-            expected_redirect_uri = furl(scheme='https', host=os.environ['API_DOMAIN_NAME'], path='internal/cb')
-            self.assertEqual(redirect_url.args["redirect_uri"], str(expected_redirect_uri))
+            redirect_uri = furl(redirect_url.args["redirect_uri"])
+            self.assertTrue(redirect_uri.path.endswith('/cb'))
             self.assertEqual(redirect_url.args["scope"], scopes)
             self.assertEqual(redirect_url.host, 'humancellatlas.auth0.com')
             self.assertEqual(redirect_url.path, '/authorize')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,27 +11,28 @@ import sys
 import unittest
 from furl import furl
 
-from oauthlib.oauth2 import WebApplicationClient
-
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-os.environ['FUS_ADMIN_EMAILS'] = 'project-viewer@cool-project-188401.iam.gserviceaccount.com'
+from tests import random_hex_string, eventually
 
-import fusillade
-from fusillade import directory
-from fusillade.clouddirectory import cleanup_directory
-from tests.common import random_hex_string, eventually
-from tests import get_auth_header
-
-old_directory_name = os.getenv("FUSILLADE_DIR", None)
 directory_name = "test_api_" + random_hex_string()
-
 os.environ['OPENID_PROVIDER'] = "humancellatlas.auth0.com"
+old_directory_name = os.getenv("FUSILLADE_DIR", None)
 os.environ["FUSILLADE_DIR"] = directory_name
+
+
+from tests.common import get_auth_header, service_accounts
+import fusillade
+from fusillade import directory, User
+from fusillade.clouddirectory import cleanup_directory
 
 from tests.infra.server import ChaliceTestHarness
 # ChaliceTestHarness must be imported after FUSILLADE_DIR has be set
+
+
+def setUpModule():
+    User.provision_user(directory, service_accounts['admin']['client_email'], roles=['admin'])
 
 
 @eventually(5,1, {fusillade.errors.FusilladeException})
@@ -39,33 +40,6 @@ def tearDownModule():
     cleanup_directory(directory._dir_arn)
     if old_directory_name:
         os.environ["FUSILLADE_DIR"] = old_directory_name
-
-
-class JWTClient(WebApplicationClient):
-    def _add_bearer_token(self, uri, http_method='GET', body=None, headers=None, *args, **kwargs):
-        headers["Authorization"] = "Bearer {}".format(self.token["id_token"])
-        return uri, headers, body
-
-
-def application_secrets(domain):
-    """
-    client_secret is a public secret from the auth0 secret for the HCA DCP CLI.
-    
-    :param domain:
-    :return:
-    """
-    return {
-        "installed": {
-            "auth_uri": f"https://{domain}/authorize",
-            "client_id": "qtMgNk9fqVeclLtZl6WkbdJ59dP3WeAt",
-            "client_secret": "JDE9KHBzrvNryDdzr3gNkyCMhXEUdMrzMcBrTXoRCNM0RlODP6NzlOxqF7Yx7O1F",
-            "redirect_uris": [
-                "urn:ietf:wg:oauth:2.0:oob",
-                "http://localhost:8080"
-            ],
-            "token_uri": f"https://{domain}/oauth/token"
-        }
-    }
 
 
 class TestAuthentication(unittest.TestCase):
@@ -121,7 +95,7 @@ class TestAuthentication(unittest.TestCase):
             self.assertEqual(redirect_url.args["response_type"], 'code')
             query_params["openid_provider"] = "humancellatlas.auth0.com"
             self.assertDictEqual(json.loads(base64.b64decode(redirect_url.args["state"])), query_params)
-            expected_redirect_uri = furl(scheme='https', host=os.environ['API_DOMAIN_NAME'], path='cb')
+            expected_redirect_uri = furl(scheme='https', host=os.environ['API_DOMAIN_NAME'], path='internal/cb')
             self.assertEqual(redirect_url.args["redirect_uri"], str(expected_redirect_uri))
             self.assertEqual(redirect_url.args["scope"], scopes)
             self.assertEqual(redirect_url.host, 'humancellatlas.auth0.com')
@@ -224,7 +198,7 @@ class TestApi(unittest.TestCase):
                 with self.subTest(test['json_request_body']):
                     data=json.dumps(test['json_request_body'])
                     headers={'Content-Type': "application/json"}
-                    headers.update(get_auth_header())
+                    headers.update(get_auth_header(service_accounts['admin']))
                     resp = self.app.post('/v1/policies/evaluate', headers=headers, data=data)
                     self.assertEqual(test['response']['code'], resp.status_code)  # TODO fix
                     self.assertEqual(test['response']['result'], json.loads(resp.body)['result'])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -96,7 +96,7 @@ class TestAuthentication(unittest.TestCase):
             query_params["openid_provider"] = "humancellatlas.auth0.com"
             self.assertDictEqual(json.loads(base64.b64decode(redirect_url.args["state"])), query_params)
             redirect_uri = furl(redirect_url.args["redirect_uri"])
-            self.assertTrue(redirect_uri.path.endswith('/cb'))
+            self.assertTrue(redirect_uri.pathstr.endswith('/cb'))
             self.assertEqual(redirect_url.args["scope"], scopes)
             self.assertEqual(redirect_url.host, 'humancellatlas.auth0.com')
             self.assertEqual(redirect_url.path, '/authorize')

--- a/tests/test_clouddirectory.py
+++ b/tests/test_clouddirectory.py
@@ -5,7 +5,7 @@ from unittest import mock
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-from tests.common import random_hex_string
+from tests.common import random_hex_string, service_accounts
 import fusillade
 from fusillade.clouddirectory import cd_client, cleanup_directory, cleanup_schema, publish_schema, create_directory, \
     CloudDirectory, CloudNode
@@ -29,11 +29,11 @@ class TestCloudDirectory(unittest.TestCase):
             self.assertEqual(schema_arn_1, schema_arn_2)
 
         with self.subTest("A CloudDirectory object is returned with schema provided when create_directory is called."):
-            directory_1 = create_directory(directory_name, schema_arn_1)
+            directory_1 = create_directory(directory_name, schema_arn_1, [service_accounts['admin']['client_email']])
 
         with self.subTest("A CloudDirectory object is returned with schema provided when create_directory is called"
                           " a second time"):
-            directory_2 = create_directory(directory_name, schema_arn_1)
+            directory_2 = create_directory(directory_name, schema_arn_1, [service_accounts['admin']['client_email']])
             self.assertEqual(directory_1._dir_arn, directory_2._dir_arn)
 
         with self.subTest("A directory is deleted when cleanup_directory is called."):
@@ -56,7 +56,7 @@ class TestCloudDirectory(unittest.TestCase):
         directory_name = "test_dir_" + random_hex_string()
         schema_arn = publish_schema(schema_name, schema_version)
         self.addCleanup(cleanup_schema, schema_arn)
-        directory = create_directory(directory_name, schema_arn)
+        directory = create_directory(directory_name, schema_arn, [service_accounts['admin']['client_email']])
         self.addCleanup(cleanup_directory, CloudDirectory.from_name(directory_name)._dir_arn)
 
         folders = ['user', 'role', 'group', 'policy']
@@ -71,7 +71,7 @@ class TestCloudDirectory(unittest.TestCase):
                 resp = directory.get_object_information(role)
                 self.assertTrue(resp['ObjectIdentifier'])
 
-        for admin in fusillade.Config.get_admin_emails():
+        for admin in [service_accounts['admin']['client_email']]:
             with self.subTest(f"Admin user {admin} created when the directory is created"):
                 user = '/user/' + CloudNode.hash_name(admin)
                 resp = directory.get_object_information(user)

--- a/tests/test_clouddirectory.py
+++ b/tests/test_clouddirectory.py
@@ -8,7 +8,7 @@ sys.path.insert(0, pkg_root)  # noqa
 from tests.common import random_hex_string
 import fusillade
 from fusillade.clouddirectory import cd_client, cleanup_directory, cleanup_schema, publish_schema, create_directory, \
-    CloudDirectory
+    CloudDirectory, CloudNode
 
 admin_email = "test_email1@domain.com,test_email2@domain.com, test_email3@domain.com "
 
@@ -65,7 +65,7 @@ class TestCloudDirectory(unittest.TestCase):
                 resp = directory.get_object_information(f'/{folder}')
                 self.assertTrue(resp['ObjectIdentifier'])
 
-        roles = ['/role/admin', '/role/default_user']
+        roles = [f"/role/{CloudNode.hash_name(name)}" for name in ['admin', 'default_user']]
         for role in roles:
             with self.subTest(f"{role} roles is created when directory is created"):
                 resp = directory.get_object_information(role)
@@ -73,7 +73,7 @@ class TestCloudDirectory(unittest.TestCase):
 
         for admin in fusillade.Config.get_admin_emails():
             with self.subTest(f"Admin user {admin} created when the directory is created"):
-                user = '/user/' + quote(admin)
+                user = '/user/' + CloudNode.hash_name(admin)
                 resp = directory.get_object_information(user)
                 self.assertTrue(resp['ObjectIdentifier'])
 


### PR DESCRIPTION
…STAGE == TEST

- Moved reusable test code that uses fusillade libraries to test.common
- Moved reusable test code that does not use fusillade libraries to test.__init__
- Removed unused code from test_api
- Using test service accounts in test_api