### PR TITLE
Changing Groups to LEAF_NODE

### DIFF
--- a/fusillade/__init__.py
+++ b/fusillade/__init__.py
@@ -19,7 +19,7 @@ def get_directory():
     except FusilladeException:
         from .clouddirectory import publish_schema, create_directory
         schema_name = Config.get_schema_name()
-        schema_arn = publish_schema(schema_name, version="0.3")  # TODO make version an environment variable
+        schema_arn = publish_schema(schema_name, version="0.4")  # TODO make version an environment variable
         admins = Config.get_admin_emails()
         _directory = create_directory(directory_name, schema_arn, admins)
     return _directory

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -1198,7 +1198,7 @@ class Group(CloudNode):
         :param cloud_directory:
         :param name:
         """
-        super(Group, self).__init__(cloud_directory, 'group', name=name, object_ref=object_ref)
+        super(Group, self).__init__(cloud_directory, 'group', name=name, object_ref=object_ref, facet='LeafFacet')
         self._groups = None
         self._roles = None
 
@@ -1223,7 +1223,7 @@ class Group(CloudNode):
         filter_attribute_ranges = [
         ]
         for type_link in self.cd.list_outgoing_typed_links(self.object_ref, filter_attribute_ranges, 'association'):
-            yield type_link['SourceObjectReference']['Selector']
+            yield type_link['TargetObjectReference']['Selector']
 
     @property
     def roles(self):
@@ -1277,7 +1277,7 @@ class Role(CloudNode):
     """
 
     def __init__(self, cloud_directory: CloudDirectory, name: str = None, object_ref: str = None):
-        super(Role, self).__init__(cloud_directory, 'role', name=name, object_ref=object_ref)
+        super(Role, self).__init__(cloud_directory, 'role', name=name, object_ref=object_ref, facet='NodeFacet')
 
     @classmethod
     def create(cls,

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -327,7 +327,7 @@ class CloudDirectory:
                                                AttributeNames=attributes
                                                )
 
-    def get_object_attribute_list(self, facet="UserFacet", **kwargs) -> typing.List[typing.Dict[str, typing.Any]]:
+    def get_object_attribute_list(self, facet="LeafFacet", **kwargs) -> typing.List[typing.Dict[str, typing.Any]]:
         return [dict(Key=dict(SchemaArn=self.schema, FacetName=facet, Name=k), Value=dict(StringValue=v))
                 for k, v in kwargs.items()]
 
@@ -389,8 +389,8 @@ class CloudDirectory:
 
     def create_folder(self, path: str, name: str) -> None:
         """ A folder is just a Group"""
-        schema_facets = [dict(SchemaArn=self.schema, FacetName="BasicFacet")]
-        object_attribute_list = self.get_object_attribute_list(facet="BasicFacet", name=name, obj_type="folder")
+        schema_facets = [dict(SchemaArn=self.schema, FacetName="NodeFacet")]
+        object_attribute_list = self.get_object_attribute_list(facet="NodeFacet", name=name, obj_type="folder")
         try:
             cd_client.create_object(DirectoryArn=self._dir_arn,
                                     SchemaFacets=schema_facets,
@@ -630,17 +630,17 @@ class CloudDirectory:
         }
 
     def batch_attach_typed_link(self,
-                                source_ref: str,
-                                target_ref: str,
+                                parent: str,
+                                child: str,
                                 facet_name: str,
                                 attributes: typing.Dict) -> typing.Dict[str, typing.Any]:
         return {
             'AttachTypedLink': {
                 'SourceObjectReference': {
-                    'Selector': source_ref
+                    'Selector': parent
                 },
                 'TargetObjectReference': {
-                    'Selector': target_ref
+                    'Selector': child
                 },
                 'TypedLinkFacet': {
                     'SchemaArn': self.schema,
@@ -748,7 +748,7 @@ class CloudNode:
                  object_type: str,
                  name: str = None,
                  object_ref: str = None,
-                 facet="BasicFacet"):
+                 facet="NodeFacet"):
         """
 
         :param cloud_directory:
@@ -803,15 +803,14 @@ class CloudNode:
             for type_link in self.cd.list_incoming_typed_links(self.object_ref, filter_attribute_ranges, 'association')
         ]
 
-    def _add_links(self, links: typing.List[str], link_type: str):
+    def _add_links_batch(self, links: typing.List[str], link_type: str):
         """
         Attaches links to this object in CloudDirectory.
         """
         if not links:
-            return
+            return []
         parent_path = self.cd.get_obj_type_path(link_type)
         batch_attach_object = self.cd.batch_attach_object
-        batch_attach_typed_link = self.cd.batch_attach_typed_link
         operations = []
         for link in links:
             parent_ref = f"{parent_path}{self.hash_name(link)}"
@@ -822,6 +821,19 @@ class CloudNode:
                     self._get_link_name(parent_ref, self.object_ref)
                 )
             )
+        return operations
+
+    def _add_typed_links_batch(self, links: typing.List[str], link_type: str):
+        """
+        Attaches links to this object in CloudDirectory.
+        """
+        if not links:
+            return []
+        parent_path = self.cd.get_obj_type_path(link_type)
+        batch_attach_typed_link = self.cd.batch_attach_typed_link
+        operations = []
+        for link in links:
+            parent_ref = f"{parent_path}{self.hash_name(link)}"
             attributes = {
                 'parent_type': link_type,
                 'child_type': self._object_type,
@@ -834,18 +846,16 @@ class CloudNode:
                     attributes
                 )
             )
-        self.cd.batch_write(operations)
+        return operations
 
-    def _remove_links(self, links: typing.List[str], link_type: str):
+    def _remove_links_batch(self, links: typing.List[str], link_type: str):
         """
         Removes links from this object in CloudDirectory.
         """
         if not links:
-            return
+            return []
         parent_path = self.cd.get_obj_type_path(link_type)
         batch_detach_object = self.cd.batch_detach_object
-        batch_detach_typed_link = self.cd.batch_detach_typed_link
-        make_typed_link_specifier = self.cd.make_typed_link_specifier
         operations = []
         for link in links:
             parent_ref = f"{parent_path}{self.hash_name(link)}"
@@ -855,6 +865,20 @@ class CloudNode:
                     self._get_link_name(parent_ref, self.object_ref)
                 )
             )
+        return operations
+
+    def _remove_typed_links_batch(self, links: typing.List[str], link_type: str):
+        """
+        Removes links from this object in CloudDirectory.
+        """
+        if not links:
+            return []
+        parent_path = self.cd.get_obj_type_path(link_type)
+        batch_detach_typed_link = self.cd.batch_detach_typed_link
+        make_typed_link_specifier = self.cd.make_typed_link_specifier
+        operations = []
+        for link in links:
+            parent_ref = f"{parent_path}{self.hash_name(link)}"
             typed_link_specifier = make_typed_link_specifier(
                 parent_ref,
                 self.object_ref,
@@ -862,7 +886,7 @@ class CloudNode:
                 {'parent_type': link_type, 'child_type': self._object_type}
             )
             operations.append(batch_detach_typed_link(typed_link_specifier))
-        self.cd.batch_write(operations)
+        return operations
 
     def lookup_policies(self) -> typing.List[str]:
         return self.cd.lookup_policy(self.object_ref)
@@ -1001,7 +1025,7 @@ class User(CloudNode):
                                    'user',
                                    name=name,
                                    object_ref=object_ref,
-                                   facet='UserFacet')
+                                   facet='LeafFacet')
         self._status = None
         self._groups: typing.Optional[typing.List[str]] = None
         self._roles: typing.Optional[typing.List[str]] = None
@@ -1094,11 +1118,15 @@ class User(CloudNode):
         return self._groups
 
     def add_groups(self, groups: typing.List[str]):
-        self._add_links(groups, 'group')
+        operations = []
+        operations.extend(self._add_typed_links_batch(groups, 'group'))
+        self.cd.batch_write(operations)
         self._groups = None  # update groups
 
     def remove_groups(self, groups: typing.List[str]):
-        self._remove_links(groups, 'group')
+        operations = []
+        operations.extend(self._remove_typed_links_batch(groups, 'group'))
+        self.cd.batch_write(operations)
         self._groups = None  # update groups
 
     @property
@@ -1108,11 +1136,17 @@ class User(CloudNode):
         return self._roles
 
     def add_roles(self, roles: typing.List[str]):
-        self._add_links(roles, 'role')
+        operations = []
+        operations.extend(self._add_links_batch(roles, 'role'))
+        operations.extend(self._add_typed_links_batch(roles, 'role'))
+        self.cd.batch_write(operations)
         self._roles = None  # update roles
 
     def remove_roles(self, roles: typing.List[str]):
-        self._remove_links(roles, 'role')
+        operations = []
+        operations.extend(self._remove_links_batch(roles, 'role'))
+        operations.extend(self._remove_typed_links_batch(roles, 'role'))
+        self.cd.batch_write(operations)
         self._roles = None  # update roles
 
 
@@ -1139,7 +1173,7 @@ class Group(CloudNode):
         if not statement:
             statement = get_json_file(default_group_policy_path)
         cls._verify_statement(statement)
-        cloud_directory.create_object(cls.hash_name(name), 'BasicFacet', name=name, obj_type="group")
+        cloud_directory.create_object(cls.hash_name(name), 'LeafFacet', name=name, obj_type="group")
         new_node = cls(cloud_directory, name)
         new_node._set_statement(statement)
         return new_node
@@ -1149,8 +1183,10 @@ class Group(CloudNode):
         Retrieves the object_refs for all user in this group.
         :return: (user name, user object reference)
         """
-        for link, object_ref in self.cd.list_object_children(self.object_ref):
-            yield User(self.cd, object_ref).name, object_ref
+        filter_attribute_ranges = [
+        ]
+        for type_link in self.cd.list_outgoing_typed_links(self.object_ref, filter_attribute_ranges, 'association'):
+            yield type_link['SourceObjectReference']['Selector']
 
     @property
     def roles(self):
@@ -1159,19 +1195,31 @@ class Group(CloudNode):
         return self._roles
 
     def add_roles(self, roles: typing.List[str]):
-        self._add_links(roles, 'role')
+        operations = []
+        operations.extend(self._add_links_batch(roles, 'role'))
+        operations.extend(self._add_typed_links_batch(roles, 'role'))
+        self.cd.batch_write(operations)
         self._roles = None  # update roles
 
     def remove_roles(self, roles: typing.List[str]):
-        self._remove_links(roles, 'role')
+        operations = []
+        operations.extend(self._remove_links_batch(roles, 'role'))
+        operations.extend(self._remove_typed_links_batch(roles, 'role'))
+        self.cd.batch_write(operations)
         self._roles = None  # update roles
 
     def add_users(self, users: typing.List[User]) -> None:
         if users:
             operations = [
-                self.cd.batch_attach_object(self.object_ref,
-                                            i.object_ref,
-                                            self._get_link_name(self.object_ref, i.object_ref))
+                self.cd.batch_attach_typed_link(
+                    self.object_ref,
+                    i.object_ref,
+                    'association',
+                    {
+                        'parent_type': self._object_type,
+                        'child_type': i._object_type,
+                    }
+                )
                 for i in users]
             self.cd.batch_write(operations)
 
@@ -1203,7 +1251,7 @@ class Role(CloudNode):
             statement = get_json_file(default_role_path)
         cls._verify_statement(statement)
         try:
-            cloud_directory.create_object(cls.hash_name(name), 'BasicFacet', name=name, obj_type='role')
+            cloud_directory.create_object(cls.hash_name(name), 'NodeFacet', name=name, obj_type='role')
         except cd_client.exceptions.LinkNameAlreadyInUseException:
             raise FusilladeHTTPException(status=409, title="Conflict", detail="The object already exists")
         new_node = cls(cloud_directory, name)

--- a/fusillade/directory_schema.json
+++ b/fusillade/directory_schema.json
@@ -1,7 +1,7 @@
 {
   "sourceSchemaArn": "",
   "facets": {
-    "BasicFacet": {
+    "NodeFacet": {
       "facetAttributes": {
         "name": {
           "attributeDefinition": {
@@ -38,7 +38,7 @@
       },
       "objectType": "NODE"
     },
-    "UserFacet": {
+    "LeafFacet": {
       "facetAttributes": {
         "name": {
           "attributeDefinition": {
@@ -86,7 +86,7 @@
               }
             }
           },
-          "requiredBehavior": "REQUIRED_ALWAYS"
+          "requiredBehavior": "NOT_REQUIRED"
         }
       },
       "objectType": "LEAF_NODE"

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -68,7 +68,7 @@ class TestGroup(unittest.TestCase):
             group = Group.create(self.directory, "test")
             user = User.provision_user(self.directory, "another@place.com")
             group.add_users([user])
-            actual_users = [i[1] for i in group.get_users()]
+            actual_users = [i for i in group.get_users()]
             self.assertEqual(len(actual_users), 1)
             self.assertEqual(User(self.directory,object_ref=actual_users[0]).name, user.name)
 
@@ -98,10 +98,15 @@ class TestGroup(unittest.TestCase):
 
     def test_roles(self):
         roles = ['role1', 'role2']
-        [Role.create(self.directory, name) for name in roles]
-        group = Group.create(self.directory, "test_roles")
-        group.add_roles(roles)
-        group.roles()
+        role_objs = [Role.create(self.directory, name, create_test_statement(name)) for name in roles]
+        with self.subTest("multiple roles return when multiple roles are attached to group."):
+            group = Group.create(self.directory, "test_roles")
+            group.add_roles(roles)
+            self.assertEqual(len(group.roles), 2)
+        with self.subTest("policies inherited from roles are returned when lookup policies is called"):
+            group_policies = sorted(group.lookup_policies())
+            role_policies = sorted([role.statement for role in role_objs] + [self.default_group_statement])
+            self.assertListEqual(group_policies, role_policies)
 
 
 if __name__ == '__main__':

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -6,7 +6,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from fusillade.errors import FusilladeHTTPException
 from fusillade.clouddirectory import User, Group, cd_client, cleanup_directory, cleanup_schema, get_json_file, \
-    default_group_policy_path
+    default_group_policy_path, Role
 from tests.common import new_test_directory, create_test_statement
 
 
@@ -95,6 +95,14 @@ class TestGroup(unittest.TestCase):
                 group.add_users([user])
             except cd_client.exceptions.BatchWriteException:
                 pass
+
+    def test_roles(self):
+        roles = ['role1', 'role2']
+        [Role.create(self.directory, name) for name in roles]
+        group = Group.create(self.directory, "test_roles")
+        group.add_roles(roles)
+        group.roles()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -211,8 +211,8 @@ class TestUser(unittest.TestCase):
         user.add_roles(role_names)
         user.add_groups(group_names)
         user.statement = self.default_policy
-        user_role_names = [Role(self.directory,None,role).name for role in user.roles]
-        user_group_names = [Group(self.directory,None,group).name for group in user.groups]
+        user_role_names = [Role(self.directory, object_ref=role).name for role in user.roles]
+        user_group_names = [Group(self.directory, object_ref=group).name for group in user.groups]
 
         self.assertListEqual(sorted(user_role_names), ['default_user'] + role_names)
         self.assertEqual(sorted(user_group_names), group_names)


### PR DESCRIPTION
fixes #119 

* added a test case to verify that a `Group` can be assigned multiple roles
* `Group` has been change from a `NODE` to a `LEAF_NODE`
* `Group` is no longer attached to a User with a parent child link
* `User.lookup_policy` is multithreads when a user has a group membership.
* split `Clouddirectory.lookup_policy` into `Clouddirectory.get_policies` to allow better multithreading
* separated `CloudNode._add_links` into `CloudNode._add_typed_links_batch` ands `CloudNode._add_links_batch` to separate when parent child links from typed links. 
* separated `CloudNode._remove_links` into `CloudNode._remove_typed_links_batch` ands `CloudNode._add_links_batch` to separate when parent child links from typed links. 
* modified how `Group` adds and removes users to support its type change to `LEAF_NODE`