### PR TITLE
[FIX] Using token_info in endpoints to retrieve the requesting user's email

### DIFF
--- a/fusillade/api/evaluate.py
+++ b/fusillade/api/evaluate.py
@@ -8,8 +8,10 @@ from fusillade import User, directory
 from fusillade.utils.authorize import assert_authorized, evaluate_policy
 
 
-def evaluate_policy_api(user, body):
-    with AuthorizeThread(user, ['fus:Evaluate'], ['arn:hca:fus:*:*:user']):
+def evaluate_policy_api(token_info, body):
+    with AuthorizeThread(token_info['https://auth.data.humancellatlas.org/email'],
+                         ['fus:Evaluate'],
+                         ['arn:hca:fus:*:*:user']):
         policies = User(directory, body['principal']).lookup_policies()
         result = evaluate_policy(body['principal'], body['action'], body['resource'], policies)
     return make_response(jsonify(**body, result=result), 200)

--- a/fusillade/api/roles/__init__.py
+++ b/fusillade/api/roles/__init__.py
@@ -4,19 +4,21 @@ from fusillade import Role, directory
 from fusillade.utils.authorize import assert_authorized
 
 
-def put_new_role(user: str):
-    assert_authorized(user, ['fus:PutRole'], ['arn:hca:fus:*:*:role'])
+def put_new_role(token_info: dict):
+    assert_authorized(token_info['https://auth.data.humancellatlas.org/email'], ['fus:PutRole'], ['arn:hca:fus:*:*:role'])
     json_body = request.json
     Role.create(directory, json_body['name'], statement=json_body.get('policy'))
     return make_response(f"New role {json_body['name']} created.", 201)
 
 
-def get_roles():
+def get_roles(token_info: dict):
     pass
 
 
-def get_role(user: str, role_id: str):
-    assert_authorized(user, ['fus:GetRole'], [f'arn:hca:fus:*:*:role/{role_id}'])
+def get_role(token_info: dict, role_id: str):
+    assert_authorized(token_info['https://auth.data.humancellatlas.org/email'],
+                      ['fus:GetRole'],
+                      [f'arn:hca:fus:*:*:role/{role_id}'])
     role = Role(directory, role_id)
     resp = dict(
         name=role.name,
@@ -25,8 +27,10 @@ def get_role(user: str, role_id: str):
     return make_response(jsonify(resp), 200)
 
 
-def put_role_policy(user: str, role_id: str):
-    assert_authorized(user, ['fus:PutRole'], [f'arn:hca:fus:*:*:role/{role_id}'])
+def put_role_policy(token_info: dict, role_id: str):
+    assert_authorized(token_info['https://auth.data.humancellatlas.org/email'],
+                      ['fus:PutRole'],
+                      [f'arn:hca:fus:*:*:role/{role_id}'])
     role = Role(directory, role_id)
     role.statement = request.json['policy']
     return make_response('Role policy updated.', 200)

--- a/fusillade/api/roles/__init__.py
+++ b/fusillade/api/roles/__init__.py
@@ -5,7 +5,9 @@ from fusillade.utils.authorize import assert_authorized
 
 
 def put_new_role(token_info: dict):
-    assert_authorized(token_info['https://auth.data.humancellatlas.org/email'], ['fus:PutRole'], ['arn:hca:fus:*:*:role'])
+    assert_authorized(token_info['https://auth.data.humancellatlas.org/email'],
+                      ['fus:PutRole'],
+                      ['arn:hca:fus:*:*:role'])
     json_body = request.json
     Role.create(directory, json_body['name'], statement=json_body.get('policy'))
     return make_response(f"New role {json_body['name']} created.", 201)

--- a/tests/common.py
+++ b/tests/common.py
@@ -73,7 +73,8 @@ def get_service_jwt(service_credentials, email=True, audience=None):
                'aud': audience or Config.audience,
                'iat': iat,
                'exp': exp,
-               'scope': ['email', 'openid', 'offline_access']
+               'scope': ['email', 'openid', 'offline_access'],
+               'https://auth.data.humancellatlas.org/email': service_credentials["client_email"]
                }
     if email:
         payload['email'] = service_credentials["client_email"]


### PR DESCRIPTION
This allows both user credentials and google service accounts to authorize correctly