### PR TITLE
Adding Health endpoint

### DIFF
--- a/fusillade-internal-api.yml
+++ b/fusillade-internal-api.yml
@@ -24,7 +24,7 @@ paths:
         200:
           description: Version returned
 
-  /status:
+  /health:
     get:
       summary: return the health status of the deployed system
       operationId: fusillade.api.internal.health_check

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 project_arn = "arn:aws:clouddirectory:us-east-1:861229788715:"  # TODO move to config.py
 cd_client = aws_clients.clouddirectory
+iam = aws_clients.iam
 
 proj_path = os.path.dirname(__file__)
 
@@ -753,6 +754,37 @@ class CloudDirectory:
             ConsistencyLevel='EVENTUAL'
         )
 
+    def get_health_status(self) -> dict:
+        """
+        Runs a health check on AWS cloud directory and iam policy simulator
+        :return: the status of the services.
+        """
+        health_status = {}
+        try:
+            iam.simulate_custom_policy(
+                PolicyInputList=[json.dumps({
+                    "Version": "2012-10-17",
+                    "Statement": [{
+                        "Sid": "DefaultRole",
+                        "Effect": "Deny",
+                        "Action": ["fake:action"],
+                        "Resource": "fake:resource"
+                    }]})],
+                ActionNames=["fake:action"],
+                ResourceArns=["arn:aws:iam::123456789012:user/Bob"])
+        except Exception:
+            health_status.update(iam_health_status='unhealthy')
+        else:
+            health_status.update(iam_health_status='ok')
+
+        try:
+            status = self.get_object_information('/')['ResponseMetadata']['HTTPStatusCode']
+        except Exception:
+            health_status.update(clouddirectory_health_status='unhealthy')
+        else:
+            health_status.update(clouddirectory_health_status='ok')
+        return health_status
+
 
 class CloudNode:
     """
@@ -1041,7 +1073,7 @@ class CloudNode:
         Verifies the policy statement is syntactically correct based on AWS's IAM Policy Grammar.
         A fake ActionNames and ResourceArns are used to facilitate the simulation of the policy.
         """
-        iam = aws_clients.iam
+
         try:
             iam.simulate_custom_policy(PolicyInputList=[statement],
                                        ActionNames=["fake:action"],

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -778,7 +778,7 @@ class CloudDirectory:
             health_status.update(iam_health_status='ok')
 
         try:
-            status = self.get_object_information('/')['ResponseMetadata']['HTTPStatusCode']
+            self.get_object_information('/')['ResponseMetadata']['HTTPStatusCode']
         except Exception:
             health_status.update(clouddirectory_health_status='unhealthy')
         else:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -235,6 +235,13 @@ class TestApi(unittest.TestCase):
         resp = self.app.get('/internal/version')
         resp.raise_for_status()
 
+    def test_health_check(self):
+        resp = self.app.get('/internal/health')
+        resp.raise_for_status()
+        body = json.loads(resp.body)
+        self.assertEqual(body['health_status'], 'ok')
+        self.assertTrue(isinstance(body['services'], dict))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- renamed /internal/status to /internal/health
- added health check functions for cloud directory and iam policy simulator
- updated health check test case.

- GET /internal/health response:
```json
{
  "health_status": "ok",
  "services": {
     "openid_provider_health_status": "ok | unhealthy",
     "clouddirectory_health_status": "ok | unhealthy",
     "iam_health_status": "ok | unhealthy"
  }
}
```
connects to https://github.com/HumanCellAtlas/fusillade/issues/35

Fixes https://github.com/HumanCellAtlas/fusillade/issues/35
Fixes https://github.com/HumanCellAtlas/fusillade/issues/76