### PR TITLE
Adding Public user and User_default group

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -72,12 +72,10 @@ authenticate users. This file is uploaded to AWS secrets manager using `make set
   more admins are required assign a user the admin role.
 - Environment variables can be set in `environment.local` for convenience.
 - **Optionally** Before deploying fusillade you can modify the [default policies and roles](../blob/master/policies) 
- to suite your 
- needs. The `default_admin_role.json` is policy attached to the fusillade_admin role created during deployment. The 
- `default_group_policy.json` is assigned to all new group when they are created. The `default_user_role.json` is the 
- role
- assigned to the group `default_user` which is created during deployment. All of these policies and role can be 
- modified after deployment using the fusillade API.
+ to suite your needs. The `default_admin_role.json` is policy attached to the fusillade_admin role created during 
+ deployment. The `default_group_policy.json` is assigned to all new group when they are created. The 
+ `default_user_role.json` is the role assigned to the group `default_user` which is created during deployment. All of 
+ these policies and role can be modified after deployment using the fusillade API.
 
 ## Set secrets
 Fusillade uses AWS Secret Store for its secrets. Use ./scripts/set_secrets to set the following secrets:

--- a/Readme.md
+++ b/Readme.md
@@ -71,8 +71,13 @@ authenticate users. This file is uploaded to AWS secrets manager using `make set
   is only used when fusillade is first deployed to create the first users. Afterwards this variable has no effect. If
   more admins are required assign a user the admin role.
 - Environment variables can be set in `environment.local` for convenience.
-- **Optionally** modify the [default policies and roles](../blob/master/policies) to suite your needs prior to 
-  deployment. 
+- **Optionally** Before deploying fusillade you can modify the [default policies and roles](../blob/master/policies) 
+ to suite your 
+ needs. The `default_admin_role.json` is policy attached to the fusillade_admin role created during deployment. The 
+ `default_group_policy.json` is assigned to all new group when they are created. The `default_user_role.json` is the 
+ role
+ assigned to the group `default_user` which is created during deployment. All of these policies and role can be 
+ modified after deployment using the fusillade API.
 
 ## Set secrets
 Fusillade uses AWS Secret Store for its secrets. Use ./scripts/set_secrets to set the following secrets:
@@ -84,13 +89,18 @@ expected format
 
 # Using Fusillade as a Service
 
-When Fusillade is first deployed two roles are created. The first role is `admin` and is assigned
-to the users created from the csv of emails found in `FUS_ADMIN_EMAILS`. The second role is `default_user` this role is 
-assigned to all other users created using the login API. The policies assigned to these roles can be customized prior to
-deployment. Afterwards all modifications to users, roles, groups, and policies must be made using the fusillade API.
+The following are created on deployment:
+* `/role/fusillade_admin` - contains a policy based on `default_admin_role.json`
+* `/role/default_user` - contains a policy based on `default_user_role.json`
+* `/user/{FUS_ADMIN_EMAILS}` - a user for each admin in `FUS_ADMIN_EMAILS` with `/role/fusillade_admin` attached.
+* `/user/public` -  a user for evaluating policies without an authenticated principle. Attach policies to this role 
+ to limit what unauthenticated user can do.
+* `/group/user_default` - a group assigned to all users upon creation. It has the `/role/default_user` attached. Add 
+ new roles to this group to apply that role to all users.
+
+All of these resources can be modified using the fusillade API after deployment.
 
 ## Adding Users to Roles
-
 New admins can be assigned using the fusillade API and assigning the role of admin to a user.
 
 # Using Fusillade as a library

--- a/tests/base_api_test.py
+++ b/tests/base_api_test.py
@@ -20,7 +20,7 @@ class BaseAPITest():
     @classmethod
     def setUpClass(cls):
         try:
-            User.provision_user(directory, service_accounts['admin']['client_email'], roles=['admin'])
+            User.provision_user(directory, service_accounts['admin']['client_email'], roles=['fusillade_admin'])
         except Exception:
             pass
 
@@ -58,6 +58,6 @@ class BaseAPITest():
         self.assertEqual(200, resp.status_code)
         self.assertFalse("Link" in resp.headers)
         next_results = json.loads(resp.body)[key]
-        self.assertEqual(len(next_results), per_page)
+        self.assertLessEqual(len(next_results), per_page)
         result.extend(next_results)
         return result

--- a/tests/test_clouddirectory.py
+++ b/tests/test_clouddirectory.py
@@ -66,7 +66,7 @@ class TestCloudDirectory(unittest.TestCase):
                 resp = directory.get_object_information(f'/{folder}')
                 self.assertTrue(resp['ObjectIdentifier'])
 
-        roles = [f"/role/{CloudNode.hash_name(name)}" for name in ['admin', 'default_user']]
+        roles = [f"/role/{CloudNode.hash_name(name)}" for name in ['fusillade_admin', 'default_user']]
         for role in roles:
             with self.subTest(f"{role} roles is created when directory is created"):
                 resp = directory.get_object_information(role)
@@ -78,6 +78,15 @@ class TestCloudDirectory(unittest.TestCase):
                 resp = directory.get_object_information(user)
                 self.assertTrue(resp['ObjectIdentifier'])
 
+        with self.subTest(f"Public User created when the directory is created"):
+            group = '/user/' + CloudNode.hash_name('public')
+            resp = directory.get_object_information(group)
+            self.assertTrue(resp['ObjectIdentifier'])
+
+        with self.subTest(f"Public Group created when the directory is created"):
+            group = '/group/' + CloudNode.hash_name('public')
+            resp = directory.get_object_information(group)
+            self.assertTrue(resp['ObjectIdentifier'])
 
             expected_tags = [
                 {'Key': 'project', "Value": os.getenv("FUS_PROJECT_TAG", '')},

--- a/tests/test_clouddirectory.py
+++ b/tests/test_clouddirectory.py
@@ -84,7 +84,7 @@ class TestCloudDirectory(unittest.TestCase):
             self.assertTrue(resp['ObjectIdentifier'])
 
         with self.subTest(f"Public Group created when the directory is created"):
-            group = '/group/' + CloudNode.hash_name('public')
+            group = '/group/' + CloudNode.hash_name('user_default')
             resp = directory.get_object_information(group)
             self.assertTrue(resp['ObjectIdentifier'])
 

--- a/tests/test_group_api.py
+++ b/tests/test_group_api.py
@@ -143,7 +143,7 @@ class TestGroupApi(BaseAPITest, unittest.TestCase):
 
             )
             self.assertEqual(201, resp.status_code)
-        self._test_paging('/v1/groups', headers, 5, 'groups')
+        self._test_paging('/v1/groups', headers, 6, 'groups')
 
     def test_put_group_roles(self):
         tests = [
@@ -210,5 +210,18 @@ class TestGroupApi(BaseAPITest, unittest.TestCase):
         users = [User.provision_user(directory, f"user_{i}",groups=[name]).name for i in range(10)]
         self._test_paging(f'/v1/group/{name}/users', headers, 5, key)
 
+    def test_default_group(self):
+        headers = {'Content-Type': "application/json"}
+        users = ['admin', 'user']
+        for user in users:
+            with self.subTest(f"{user} has permission to access default_user group."):
+                headers.update(get_auth_header(service_accounts[user]))
+                resp = self.app.get(f'/v1/group/user_default', headers=headers)
+                resp.raise_for_status()
+                resp = self.app.get(f'/v1/group/user_default/roles', headers=headers)
+                resp.raise_for_status()
+                if user == 'admin':
+                    resp = self.app.get(f'/v1/group/user_default/users', headers=headers)
+                    resp.raise_for_status()
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_user_api.py
+++ b/tests/test_user_api.py
@@ -238,7 +238,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
         self.assertEqual(1, len(json.loads(resp.body)[key]))
         groups = [Group.create(directory, f"group_{i}").name for i in range(10)]
         user.add_groups(groups)
-        self._test_paging(f'/v1/user/{name}/groups', headers, 5, key)
+        self._test_paging(f'/v1/user/{name}/groups', headers, 6, key)
 
     def test_put_username_roles(self):
         tests = [
@@ -288,8 +288,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
         user = User.provision_user(directory, name)
         resp = self.app.get(f'/v1/user/{name}/roles', headers=headers)
         user_role_names = [Role(directory, None, role).name for role in user.roles]
-        self.assertEqual(1, len(json.loads(resp.body)[key]))
-        self.assertEqual(user_role_names, ['default_user'])
+        self.assertEqual(0, len(json.loads(resp.body)[key]))
         roles = [Role.create(directory, f"role_{i}").name for i in range(11)]
         user.add_roles(roles)
         self._test_paging(f'/v1/user/{name}/roles', headers, 6, key)

--- a/tests/test_user_api.py
+++ b/tests/test_user_api.py
@@ -143,7 +143,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
                 data=json.dumps({"user_id": f"test_post_user{i}@email.com"})
             )
             self.assertEqual(201, resp.status_code)
-        self._test_paging(f'/v1/users', headers, 6, 'users')
+        self._test_paging(f'/v1/users', headers, 7, 'users')
 
     def test_get_user(self):
         headers = {'Content-Type': "application/json"}
@@ -235,7 +235,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
         key = 'groups'
         user = User.provision_user(directory, name)
         resp = self.app.get(f'/v1/user/{name}/groups', headers=headers)
-        self.assertEqual(0, len(json.loads(resp.body)[key]))
+        self.assertEqual(1, len(json.loads(resp.body)[key]))
         groups = [Group.create(directory, f"group_{i}").name for i in range(10)]
         user.add_groups(groups)
         self._test_paging(f'/v1/user/{name}/groups', headers, 5, key)
@@ -288,7 +288,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
         user = User.provision_user(directory, name)
         resp = self.app.get(f'/v1/user/{name}/roles', headers=headers)
         user_role_names = [Role(directory, None, role).name for role in user.roles]
-        self.assertEqual(1, len(json.loads(resp.body)[key]))
+        self.assertEqual(0, len(json.loads(resp.body)[key]))
         self.assertEqual(user_role_names, ['default_user'])
         roles = [Role.create(directory, f"role_{i}").name for i in range(11)]
         user.add_roles(roles)

--- a/tests/test_user_api.py
+++ b/tests/test_user_api.py
@@ -288,7 +288,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
         user = User.provision_user(directory, name)
         resp = self.app.get(f'/v1/user/{name}/roles', headers=headers)
         user_role_names = [Role(directory, None, role).name for role in user.roles]
-        self.assertEqual(0, len(json.loads(resp.body)[key]))
+        self.assertEqual(1, len(json.loads(resp.body)[key]))
         self.assertEqual(user_role_names, ['default_user'])
         roles = [Role.create(directory, f"role_{i}").name for i in range(11)]
         user.add_roles(roles)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -50,7 +50,7 @@ class TestUser(unittest.TestCase):
             self.assertRaises(FusilladeHTTPException, user.provision_user, self.directory, name)
         with self.subTest("an existing users info is retrieved when instantiating User class for an existing user"):
             user = User(self.directory, name)
-            self.assertEqual(user.lookup_policies(), self.default_user_policies)
+            self.assertEqual(sorted(user.lookup_policies()), self.default_user_policies)
 
     def test_get_groups(self):
         name = "test_get_groups@test.com"

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -7,7 +7,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from fusillade.errors import FusilladeException, FusilladeHTTPException
 from fusillade.clouddirectory import User, Group, Role, cd_client, cleanup_directory, cleanup_schema, \
-    get_json_file, default_user_policy_path, default_user_role_path
+    get_json_file, default_user_policy_path, default_user_role_path, default_group_policy_path
 from tests.common import new_test_directory, create_test_statement
 from tests.infra.testmode import standalone
 
@@ -18,7 +18,8 @@ class TestUser(unittest.TestCase):
     def setUpClass(cls):
         cls.directory, cls.schema_arn = new_test_directory()
         cls.default_policy = get_json_file(default_user_policy_path)
-        cls.default_user_role_policy = get_json_file(default_user_role_path)
+        cls.default_user_policies = sorted([get_json_file(default_user_role_path),
+                                        get_json_file(default_group_policy_path)])
 
     @classmethod
     def tearDownClass(cls):
@@ -44,12 +45,12 @@ class TestUser(unittest.TestCase):
         user = User(self.directory, name)
         with self.subTest("new user is automatically provisioned on demand with default settings when "
                           "lookup_policy is called for a new user."):
-            self.assertEqual(user.lookup_policies(), [self.default_user_role_policy])
+            self.assertEqual(sorted(user.lookup_policies()), self.default_user_policies)
         with self.subTest("error is returned when provision_user is called for an existing user"):
             self.assertRaises(FusilladeHTTPException, user.provision_user, self.directory, name)
         with self.subTest("an existing users info is retrieved when instantiating User class for an existing user"):
             user = User(self.directory, name)
-            self.assertEqual(user.lookup_policies(), [self.default_user_role_policy])
+            self.assertEqual(user.lookup_policies(), self.default_user_policies)
 
     def test_get_groups(self):
         name = "test_get_groups@test.com"
@@ -57,27 +58,27 @@ class TestUser(unittest.TestCase):
         groups = [Group.create(self.directory, *i) for i in test_groups]
 
         user = User.provision_user(self.directory, name)
-        with self.subTest("A user is in no groups when user is first created."):
-            self.assertEqual(len(user.groups), 0)
+        with self.subTest("A user is in the public group when user is first created."):
+            self.assertEqual(Group(self.directory, object_ref=user.groups[0]).name, 'user_default')
 
         user.add_groups([])
         with self.subTest("A user is added to no groups when add_groups is called with no groups"):
-            self.assertEqual(len(user.groups), 0)
+            self.assertEqual(len(user.groups), 1)
 
         with self.subTest("An error is returned when add a user to a group that does not exist."):
             with self.assertRaises(cd_client.exceptions.BatchWriteException) as ex:
                 user.add_groups(["ghost_group"])
                 self.assertTrue(ex.response['Error']['Message'].endswith("/ group / ghost_group\\' does not exist.'"))
-            self.assertEqual(len(user.groups), 0)
+            self.assertEqual(len(user.groups), 1)
 
         user.add_groups([group.name for group in groups])
         with self.subTest("A user is added to multiple groups when add_groups is called with multiple groups"):
-            self.assertEqual(len(user.groups), 5)
+            self.assertEqual(len(user.groups), 6)
 
         with self.subTest("A user inherits the groups policies when joining a group"):
             policies = set(user.lookup_policies())
             expected_policies = set([i[1] for i in test_groups])
-            expected_policies.add(self.default_user_role_policy)
+            expected_policies.update(self.default_user_policies)
             self.assertEqual(policies, expected_policies)
 
     def test_remove_groups(self):
@@ -88,18 +89,18 @@ class TestUser(unittest.TestCase):
         with self.subTest("A user is removed from a group when remove_group is called for a group the user belongs "
                           "to."):
             user.add_groups(groups)
-            self.assertEqual(len(user.groups), 5)
+            self.assertEqual(len(user.groups), 6)
             user.remove_groups(groups)
-            self.assertEqual(len(user.groups), 0)
+            self.assertEqual(len(user.groups), 1)
         with self.subTest("Error is raised when removing a user from a group it's not in."):
             self.assertRaises(cd_client.exceptions.BatchWriteException, user.remove_groups, groups)
-            self.assertEqual(len(user.groups), 0)
+            self.assertEqual(len(user.groups), 1)
         with self.subTest("An error is raised and the user is not removed from any groups when the user is in some of "
                           "the groups to remove."):
             user.add_groups(groups[:2])
-            self.assertEqual(len(user.groups), 2)
+            self.assertEqual(len(user.groups), 3)
             self.assertRaises(cd_client.exceptions.BatchWriteException, user.remove_groups, groups)
-            self.assertEqual(len(user.groups), 2)
+            self.assertEqual(len(user.groups), 3)
 
     def test_set_policy(self):
         name = "test_set_policy@test.com"
@@ -148,9 +149,8 @@ class TestUser(unittest.TestCase):
         user = User.provision_user(self.directory, name)
         user_role_names = [Role(self.directory,None,role).name for role in user.roles]
         with self.subTest("a user has the default_user roles when created."):
-            self.assertEqual(user_role_names, ['default_user'])
+            self.assertEqual(user_role_names, [])
 
-        user.remove_roles(['default_user'])
         role_name, role_statement = test_roles[0]
         with self.subTest("A user has one role when a role is added."):
             user.add_roles([role_name])
@@ -171,7 +171,8 @@ class TestUser(unittest.TestCase):
 
         user.statement = self.default_policy
         with self.subTest("A user inherits a roles policies when a role is added to a user."):
-            self.assertListEqual(sorted(user.lookup_policies()), sorted([user.statement, role_statement]))
+            self.assertListEqual(sorted(user.lookup_policies()),
+                                 sorted([user.statement, role_statement, *self.default_user_policies]))
 
         with self.subTest("A role is removed from user when remove role is called."):
             user.remove_roles([role_name])
@@ -184,7 +185,7 @@ class TestUser(unittest.TestCase):
 
         with self.subTest("A user inherits multiple role policies when the user has multiple roles."):
             self.assertListEqual(sorted(user.lookup_policies()),
-                                 sorted([user.statement] + role_statements))
+                                 sorted([user.statement, *self.default_user_policies, *role_statements]))
 
         with self.subTest("A user's roles are listed when a listing a users roles."):
             user_role_names = [Role(self.directory, None, role).name for role in user.roles]
@@ -217,10 +218,10 @@ class TestUser(unittest.TestCase):
         user_role_names = [Role(self.directory, object_ref=role).name for role in user.roles]
         user_group_names = [Group(self.directory, object_ref=group).name for group in user.groups]
 
-        self.assertListEqual(sorted(user_role_names), ['default_user'] + role_names)
-        self.assertEqual(sorted(user_group_names), group_names)
+        self.assertListEqual(sorted(user_role_names), role_names)
+        self.assertEqual(sorted(user_group_names), group_names + ['user_default'])
         self.assertSequenceEqual(sorted(user.lookup_policies()), sorted(
-            [user.statement, self.default_user_role_policy] + group_statements + role_statements)
+            [user.statement, *self.default_user_policies] + group_statements + role_statements)
                              )
 
     @unittest.skip("TODO: unfinished and low priority")


### PR DESCRIPTION
- A new user is added to group/public when created
- New roles can be added to group/public to modify what all public users can do by default.
- A public user is all user.

- A public user has been created at user/public to allow unauthenticated users access to public resources.
- the public user is part of the public group.
- public users can be disabled by calling /user/public/disable

# Test Plan
- Updated test cases

- Depends on #178
- fixes #176 