### PR TITLE
Pre-Resource Policies

### DIFF
--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -905,20 +905,21 @@ components:
     User:
       type: object
       properties:
-        name:
+        user_id:
           $ref: '#/components/schemas/custom_identifier'
         status:
           type: string
-        policy:
-          type: string
+        policies:
+          type: object
           nullable: true
     Group:
       type: object
       properties:
         group_id:
           $ref: '#/components/schemas/custom_identifier'
-        policy:
-          type: string
+        policies:
+          type: object
+          nullable: true
         roles:
           type: array
           items:
@@ -930,10 +931,10 @@ components:
     Role:
       type: object
       properties:
-        name:
+        role_id:
           $ref: '#/components/schemas/custom_identifier'
-        policy:
-          type: string
+        policies:
+          type: object
   responses:
     206:
       description: A single page of results was retrieved.

--- a/fusillade/api/groups/__init__.py
+++ b/fusillade/api/groups/__init__.py
@@ -22,7 +22,7 @@ def get_groups(token_info: dict):
 @authorize(['fus:GetGroup'], ['arn:hca:fus:*:*:group/{group_id}/'], ['group_id'], {'fus:group_id': 'group_id'})
 def get_group(token_info: dict, group_id: str):
     group = Group(directory, group_id)
-    return make_response(jsonify(name=group.name, policy=group.get_policy()), 200)
+    return make_response(jsonify(group.get_info()), 200)
 
 
 @authorize(['fus:PutGroup'], ['arn:hca:fus:*:*:group/{group_id}/policy'], ['group_id'], {'fus:group_id': 'group_id'})

--- a/fusillade/api/groups/__init__.py
+++ b/fusillade/api/groups/__init__.py
@@ -22,13 +22,13 @@ def get_groups(token_info: dict):
 @authorize(['fus:GetGroup'], ['arn:hca:fus:*:*:group/{group_id}/'], ['group_id'], {'fus:group_id': 'group_id'})
 def get_group(token_info: dict, group_id: str):
     group = Group(directory, group_id)
-    return make_response(jsonify(name=group.name, policy=group.statement), 200)
+    return make_response(jsonify(name=group.name, policy=group.get_policy()), 200)
 
 
 @authorize(['fus:PutGroup'], ['arn:hca:fus:*:*:group/{group_id}/policy'], ['group_id'], {'fus:group_id': 'group_id'})
 def put_group_policy(token_info: dict, group_id: str):
     group = Group(directory, group_id)
-    group.statement = request.json['policy']
+    group.set_policy(request.json['policy'])
     return make_response(f"{group_id} policy modified.", 200)
 
 

--- a/fusillade/api/roles/__init__.py
+++ b/fusillade/api/roles/__init__.py
@@ -23,7 +23,7 @@ def get_role(token_info: dict, role_id: str):
     role = Role(directory, role_id)
     resp = dict(
         role_id=role.name,
-        policy=role.statement
+        policy=role.get_policy()
     )
     return make_response(jsonify(resp), 200)
 
@@ -31,5 +31,5 @@ def get_role(token_info: dict, role_id: str):
 @authorize(['fus:PutRole'], ['arn:hca:fus:*:*:role/{role_id}/'], ['role_id'])
 def put_role_policy(token_info: dict, role_id: str):
     role = Role(directory, role_id)
-    role.statement = request.json['policy']
+    role.set_policy(request.json['policy'])
     return make_response('Role policy updated.', 200)

--- a/fusillade/api/roles/__init__.py
+++ b/fusillade/api/roles/__init__.py
@@ -21,11 +21,7 @@ def get_roles(token_info: dict):
 @authorize(['fus:GetRole'], ['arn:hca:fus:*:*:role/{role_id}/'], ['role_id'])
 def get_role(token_info: dict, role_id: str):
     role = Role(directory, role_id)
-    resp = dict(
-        role_id=role.name,
-        policy=role.get_policy()
-    )
-    return make_response(jsonify(resp), 200)
+    return make_response(jsonify(role.get_info()), 200)
 
 
 @authorize(['fus:PutRole'], ['arn:hca:fus:*:*:role/{role_id}/'], ['role_id'])

--- a/fusillade/api/users/__init__.py
+++ b/fusillade/api/users/__init__.py
@@ -22,7 +22,7 @@ def get_users(token_info: dict):
 @authorize(['fus:GetUser'], ['arn:hca:fus:*:*:user/{user_id}/'], ['user_id'])
 def get_user(token_info: dict, user_id: str):
     user = User(directory, user_id)
-    return make_response(jsonify(name=user.name, status=user.status, policy=user.get_policy()), 200)
+    return make_response(jsonify(user.get_info()), 200)
 
 
 @authorize(['fus:PutUser'], ['arn:hca:fus:*:*:user/{user_id}/status'], ['user_id'])

--- a/fusillade/api/users/__init__.py
+++ b/fusillade/api/users/__init__.py
@@ -22,7 +22,7 @@ def get_users(token_info: dict):
 @authorize(['fus:GetUser'], ['arn:hca:fus:*:*:user/{user_id}/'], ['user_id'])
 def get_user(token_info: dict, user_id: str):
     user = User(directory, user_id)
-    return make_response(jsonify(name=user.name, status=user.status, policy=user.statement), 200)
+    return make_response(jsonify(name=user.name, status=user.status, policy=user.get_policy()), 200)
 
 
 @authorize(['fus:PutUser'], ['arn:hca:fus:*:*:user/{user_id}/status'], ['user_id'])
@@ -43,7 +43,7 @@ def put_user(token_info: dict, user_id: str):
 @authorize(['fus:PutUser'], ['arn:hca:fus:*:*:user/{user_id}/policy'], ['user_id'])
 def put_user_policy(token_info: dict, user_id: str):
     user = User(directory, user_id)
-    user.statement = request.json['policy']
+    user.set_policy(request.json['policy'])
     return make_response('', 200)
 
 

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -1144,7 +1144,7 @@ class CloudNode:
                 )['Attributes'][0]['Value'].popitem()[1].decode("utf-8")
             except cd_client.exceptions.ResourceNotFoundException:
                 pass
-        return policy.get('statement')
+        return policy.get('statement', '')
 
     def set_policy(self, statement: str, policy_type: str = 'IAMPolicy'):
         self._verify_statement(statement)

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -802,7 +802,7 @@ class CloudDirectory:
                 for p in policy_paths
                 for o in p['Policies']
                 if o.get('PolicyId') and o['PolicyType'] == policy_type
-                   ]
+            ]
         )
 
         # retrieve the policies in a single request

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -1146,7 +1146,7 @@ class CloudNode:
                                         'expected': policy_type,
                                         'received': receive_policy_type
                                         })
-                    self.attached_policies[policy_type]=resp['Attributes'][1]['Value']['BinaryValue'].decode("utf-8")
+                    self.attached_policies[policy_type] = resp['Attributes'][1]['Value']['BinaryValue'].decode("utf-8")
                 except cd_client.exceptions.ResourceNotFoundException:
                     pass
             return self.attached_policies.get(policy_type, '')

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -794,22 +794,22 @@ class CloudDirectory:
         ]
         return policies_paths
 
-    def get_policies(self, policy_paths: List[Dict[str, Any]]) -> List[str]:
+    def get_policies(self, policy_paths: List[Dict[str, Any]], policy_type='IAMPolicy') -> List[str]:
         # Parse the policyIds from the policies path. Only keep the unique ids
         policy_ids = set(
             [
-                (o['PolicyId'], o['PolicyType'])
+                o['PolicyId']
                 for p in policy_paths
                 for o in p['Policies']
-                if o.get('PolicyId')
-            ]
+                if o.get('PolicyId') and o['PolicyType'] == policy_type
+                   ]
         )
 
         # retrieve the policies in a single request
         operations = [
             {
                 'GetObjectAttributes': {
-                    'ObjectReference': {'Selector': f'${policy_id[0]}'},
+                    'ObjectReference': {'Selector': f'${policy_id}'},
                     'SchemaFacet': {
                         'SchemaArn': self.node_schema,
                         'FacetName': 'POLICY'

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -1181,14 +1181,14 @@ class CloudNode:
             raise FusilladeHTTPException(ex)
         else:
             logger.info(dict(message="Policy updated",
-                               object=dict(
-                                   type=self.object_type,
-                                   path_name=self._path_name
-                               ),
-                               policy=dict(
-                                   link_name=self.get_policy_name(policy_type),
-                                   policy_type=policy_type)
-                               ))
+                             object=dict(
+                                 type=self.object_type,
+                                 path_name=self._path_name
+                             ),
+                             policy=dict(
+                                 link_name=self.get_policy_name(policy_type),
+                                 policy_type=policy_type)
+                             ))
 
         self.attached_policies[policy_type] = None
 

--- a/tests/test_group_api.py
+++ b/tests/test_group_api.py
@@ -130,6 +130,7 @@ class TestGroupApi(BaseAPITest, unittest.TestCase):
         Group.create(directory,name)
         resp = self.app.get(f'/v1/group/{name}/', headers=headers)
         self.assertEqual(name, json.loads(resp.body)['name'])
+        self.assertEqual(name, json.loads(resp.body)['policies'])
 
     def test_get_groups(self):
         headers = {'Content-Type': "application/json"}

--- a/tests/test_group_api.py
+++ b/tests/test_group_api.py
@@ -119,7 +119,7 @@ class TestGroupApi(BaseAPITest, unittest.TestCase):
                 self.assertEqual(test['response']['code'], resp.status_code)
                 if resp.status_code==201:
                     resp = self.app.get(f'/v1/group/{test["json_request_body"]["group_id"]}/', headers=headers)
-                    self.assertEqual(test["json_request_body"]["group_id"], json.loads(resp.body)['name'])
+                    self.assertEqual(test["json_request_body"]["group_id"], json.loads(resp.body)['group_id'])
 
     def test_get_group(self):
         headers = {'Content-Type': "application/json"}
@@ -129,7 +129,7 @@ class TestGroupApi(BaseAPITest, unittest.TestCase):
         self.assertEqual(404, resp.status_code)
         Group.create(directory,name)
         resp = self.app.get(f'/v1/group/{name}/', headers=headers)
-        self.assertEqual(name, json.loads(resp.body)['name'])
+        self.assertEqual(name, json.loads(resp.body)['group_id'])
         self.assertTrue(json.loads(resp.body)['policies'])
 
     def test_get_groups(self):

--- a/tests/test_group_api.py
+++ b/tests/test_group_api.py
@@ -130,7 +130,7 @@ class TestGroupApi(BaseAPITest, unittest.TestCase):
         Group.create(directory,name)
         resp = self.app.get(f'/v1/group/{name}/', headers=headers)
         self.assertEqual(name, json.loads(resp.body)['name'])
-        self.assertEqual(name, json.loads(resp.body)['policies'])
+        self.assertTrue(json.loads(resp.body)['policies'])
 
     def test_get_groups(self):
         headers = {'Content-Type': "application/json"}

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -35,14 +35,14 @@ class TestGroup(unittest.TestCase):
         with self.subTest("The group is returned when the group has been created with default valid statement"):
             group = Group.create(self.directory, "new_group2")
             self.assertEqual(group.name,  "new_group2")
-            self.assertEqual(group.statement, self.default_group_statement)
+            self.assertEqual(group.get_policy(), self.default_group_statement)
 
         with self.subTest("The group is returned when the group has been created with specified valid statement."):
             group_name = "NewGroup1234"
             statement = create_test_statement(group_name)
             group = Group.create(self.directory, "new_group3", statement)
             self.assertEqual(group.name,  "new_group3")
-            self.assertEqual(group.statement, statement)
+            self.assertEqual(group.get_policy(), statement)
 
     def test_policy(self):
         group = Group.create(self.directory, "new_group")
@@ -54,13 +54,13 @@ class TestGroup(unittest.TestCase):
         group_name = "NewGroup1234"
         statement = create_test_statement(group_name)
         with self.subTest("The group policy changes when satement is set"):
-            group.statement = statement
+            group.set_policy(statement)
             policies = group.lookup_policies()
             self.assertEqual(policies[0], statement)
 
-        with self.subTest("error raised when invalid statement assigned to group.statement."):
+        with self.subTest("error raised when invalid statement assigned to group.get_policy()."):
             with self.assertRaises(FusilladeHTTPException):
-                group.statement = "invalid statement"
+                group.set_policy("invalid statement")
             self.assertEqual(policies[0], statement)
 
     def test_users(self):
@@ -107,7 +107,7 @@ class TestGroup(unittest.TestCase):
             self.assertEqual(len(group.roles), 2)
         with self.subTest("policies inherited from roles are returned when lookup policies is called"):
             group_policies = sorted(group.lookup_policies())
-            role_policies = sorted([role.statement for role in role_objs] + [self.default_group_statement])
+            role_policies = sorted([role.get_policy() for role in role_objs] + [self.default_group_statement])
             self.assertListEqual(group_policies, role_policies)
 
 

--- a/tests/test_role_api.py
+++ b/tests/test_role_api.py
@@ -55,7 +55,7 @@ class TestRoleApi(BaseAPITest, unittest.TestCase):
         self.assertEqual(200, resp.status_code)
         expected_body = {
             'role_id': role_id,
-            'policy': policy
+            'policies': {"IAMPolicy": policy}
         }
         self.assertEqual(expected_body, json.loads(resp.body))
 
@@ -72,7 +72,7 @@ class TestRoleApi(BaseAPITest, unittest.TestCase):
         self.assertEqual(200, resp.status_code)
         expected_body = {
             'role_id': role_id,
-            'policy': policy
+            'policies': {"IAMPolicy": policy}
         }
         self.assertEqual(expected_body, json.loads(resp.body))
 

--- a/tests/test_role_api.py
+++ b/tests/test_role_api.py
@@ -235,7 +235,7 @@ class TestRoleApi(BaseAPITest, unittest.TestCase):
                 if test['expected_resp'] == 200:
                     expected_body = {
                         'role_id': test['role_id'],
-                        'policy': policy
+                        'policies': {'IAMPolicy': policy}
                     }
                     self.assertEqual(expected_body, json.loads(resp.body))
 

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -31,7 +31,7 @@ class TestRole(unittest.TestCase):
             role_name = "test_role_default"
             role = Role.create(self.directory, role_name)
             self.assertEqual(role.name, role_name)
-            self.assertEqual(role.statement, self.default_role_statement)
+            self.assertEqual(role.get_policy(), self.default_role_statement)
 
     def test_role_statement(self):
         role_name = "test_role_specified"
@@ -40,23 +40,23 @@ class TestRole(unittest.TestCase):
         with self.subTest("a role is created with specified statement when role.create is called with a statement"):
             self.assertEqual(role.name, role_name)
 
-        with self.subTest("a roles statement is retrieved when role.statement is called"):
-            self.assertEqual(role.statement, statement)
+        with self.subTest("a roles statement is retrieved when role.get_policy() is called"):
+            self.assertEqual(role.get_policy(), statement)
 
-        with self.subTest("a roles statement is changed when role.statement is assigned"):
+        with self.subTest("a roles statement is changed when role.get_policy() is assigned"):
             statement = create_test_statement(f"UserPolicySomethingElse")
-            role.statement = statement
-            self.assertEqual(role.statement, statement)
+            role.set_policy(statement)
+            self.assertEqual(role.get_policy(), statement)
 
         with self.subTest("Error raised when setting policy to an invalid statement"):
             with self.assertRaises(FusilladeHTTPException):
-                role.statement = "Something else"
-            self.assertEqual(role.statement, statement)
+                role.set_policy("Something else")
+            self.assertEqual(role.get_policy(), statement)
 
         with self.subTest("an error is returned when a policy exceed 10 Kb"):
             statement = create_test_statements(150)
             with self.assertRaises(FusilladeHTTPException) as ex:
-                role.statement = statement
+                role.set_policy(statement)
 
 
 if __name__ == '__main__':

--- a/tests/test_user_api.py
+++ b/tests/test_user_api.py
@@ -131,7 +131,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
                 self.assertEqual(test['response']['code'], resp.status_code)
                 if resp.status_code == 201:
                     resp = self.app.get(f'/v1/user/{test["json_request_body"]["user_id"]}/', headers=headers)
-                    self.assertEqual(test["json_request_body"]["user_id"], json.loads(resp.body)['name'])
+                    self.assertEqual(test["json_request_body"]["user_id"], json.loads(resp.body)['user_id'])
 
     def test_get_users(self):
         headers = {'Content-Type': "application/json"}

--- a/tests/test_user_api.py
+++ b/tests/test_user_api.py
@@ -153,7 +153,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
         self.assertEqual(403, resp.status_code)
         resp = self.app.get(f'/v1/user/{name}/', headers=headers)
         resp.raise_for_status()
-        self.assertEqual(name, json.loads(resp.body)['name'])
+        self.assertEqual(name, json.loads(resp.body)['user_id'])
 
     def test_put_user_id(self):
         tests = [

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -106,7 +106,7 @@ class TestUser(unittest.TestCase):
         name = "test_set_policy@test.com"
         user = User.provision_user(self.directory, name)
         with self.subTest("The initial user policy is None, when the user is first created"):
-            self.assertEqual(user.get_policy(), None)
+            self.assertFalse(user.get_policy())
 
         statement = create_test_statement(f"UserPolicySomethingElse")
         user.set_policy(statement)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,11 +1,11 @@
+import os
+import sys
 import unittest
-import os, sys
-
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-from fusillade.errors import FusilladeException, FusilladeHTTPException
+from fusillade.errors import FusilladeHTTPException
 from fusillade.clouddirectory import User, Group, Role, cd_client, cleanup_directory, cleanup_schema, \
     get_json_file, default_user_policy_path, default_user_role_path, default_group_policy_path
 from tests.common import new_test_directory, create_test_statement
@@ -19,7 +19,7 @@ class TestUser(unittest.TestCase):
         cls.directory, cls.schema_arn = new_test_directory()
         cls.default_policy = get_json_file(default_user_policy_path)
         cls.default_user_policies = sorted([get_json_file(default_user_role_path),
-                                        get_json_file(default_group_policy_path)])
+                                            get_json_file(default_group_policy_path)])
 
     @classmethod
     def tearDownClass(cls):
@@ -33,7 +33,7 @@ class TestUser(unittest.TestCase):
         name = "user_statement@test.com"
         User.provision_user(self.directory, name, statement=self.default_policy)
         test_user = User(self.directory, name)
-        self.assertEqual(test_user.statement, self.default_policy)
+        self.assertEqual(test_user.get_policy(), self.default_policy)
 
     def test_get_attributes(self):
         name = "test_get_attributes@test.com"
@@ -106,24 +106,24 @@ class TestUser(unittest.TestCase):
         name = "test_set_policy@test.com"
         user = User.provision_user(self.directory, name)
         with self.subTest("The initial user policy is None, when the user is first created"):
-            self.assertEqual(user.statement, None)
+            self.assertEqual(user.get_policy(), None)
 
         statement = create_test_statement(f"UserPolicySomethingElse")
-        user.statement = statement
+        user.set_policy(statement)
         with self.subTest("The user policy is set when statement setter is used."):
-            self.assertEqual(user.statement, statement)
+            self.assertEqual(user.get_policy(), statement)
             self.assertIn(statement, user.lookup_policies())
 
         statement = create_test_statement(f"UserPolicySomethingElse2")
-        user.statement = statement
+        user.set_policy(statement)
         with self.subTest("The user policy changes when set_policy is used."):
-            self.assertEqual(user.statement, statement)
+            self.assertEqual(user.get_policy(), statement)
             self.assertIn(statement, user.lookup_policies())
 
         with self.subTest("Error raised when setting policy to an invalid statement"):
             with self.assertRaises(FusilladeHTTPException):
-                user.statement = "Something else"
-            self.assertEqual(user.statement, statement)
+                user.set_policy("Something else")
+            self.assertEqual(user.get_policy(), statement)
 
     def test_status(self):
         name = "test_set_policy@test.com"
@@ -147,7 +147,7 @@ class TestUser(unittest.TestCase):
         role_statements = sorted(role_statements)
 
         user = User.provision_user(self.directory, name)
-        user_role_names = [Role(self.directory,None,role).name for role in user.roles]
+        user_role_names = [Role(self.directory, None, role).name for role in user.roles]
         with self.subTest("a user has the default_user roles when created."):
             self.assertEqual(user_role_names, [])
 
@@ -164,13 +164,13 @@ class TestUser(unittest.TestCase):
 
         with self.subTest("An error is raised when adding a role that does not exist."):
             with self.assertRaises(cd_client.exceptions.BatchWriteException) as ex:
-               user.add_roles(["ghost_role"])
-               self.assertTrue(ex.response['Error']['Message'].endswith("/ role / ghost_role\\' does not exist.'"))
+                user.add_roles(["ghost_role"])
+                self.assertTrue(ex.response['Error']['Message'].endswith("/ role / ghost_role\\' does not exist.'"))
 
-        user.statement = self.default_policy
+        user.set_policy(self.default_policy)
         with self.subTest("A user inherits a roles policies when a role is added to a user."):
             self.assertListEqual(sorted(user.lookup_policies()),
-                                 sorted([user.statement, role_statement, *self.default_user_policies]))
+                                 sorted([user.get_policy(), role_statement, *self.default_user_policies]))
 
         with self.subTest("A role is removed from user when remove role is called."):
             user.remove_roles([role_name])
@@ -183,7 +183,7 @@ class TestUser(unittest.TestCase):
 
         with self.subTest("A user inherits multiple role policies when the user has multiple roles."):
             self.assertListEqual(sorted(user.lookup_policies()),
-                                 sorted([user.statement, *self.default_user_policies, *role_statements]))
+                                 sorted([user.get_policy(), *self.default_user_policies, *role_statements]))
 
         with self.subTest("A user's roles are listed when a listing a users roles."):
             user_role_names = [Role(self.directory, None, role).name for role in user.roles]
@@ -212,15 +212,15 @@ class TestUser(unittest.TestCase):
 
         user.add_roles(role_names)
         user.add_groups(group_names)
-        user.statement = self.default_policy
+        user.set_policy(self.default_policy)
         user_role_names = [Role(self.directory, object_ref=role).name for role in user.roles]
         user_group_names = [Group(self.directory, object_ref=group).name for group in user.groups]
 
         self.assertListEqual(sorted(user_role_names), role_names)
         self.assertEqual(sorted(user_group_names), group_names + ['user_default'])
         self.assertSequenceEqual(sorted(user.lookup_policies()), sorted(
-            [user.statement, *self.default_user_policies] + group_statements + role_statements)
-                             )
+            [user.get_policy(), *self.default_user_policies] + group_statements + role_statements)
+                                 )
 
     @unittest.skip("TODO: unfinished and low priority")
     def test_remove_user(self):
@@ -229,6 +229,7 @@ class TestUser(unittest.TestCase):
         self.assertEqual(len(self.directory.lookup_policy(user.reference)), 1)
         user.remove_user()
         self.directory.lookup_policy(user.reference)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is in preparation for resource policies

- adding allowed_policy_types to cloudNode, this controls what policy types can be attached to this node.
- changed statement to get/set_policy were appropriate
- added typing to groups and roles
- removed statement property for get_policy and set_policy functions
- removed policy property
- updated test cases
- Added a server side warning when a policy_type not on the allowed list is attached to a node.
- Simplified cloudNode.get_attributes
- Added cloudNode.get_info to return a clean representation of the node.
- Checking that a node exists before creating it's attached policy.
- Modified yaml to return allowed policies directly attached to cloudNode