### PR TITLE
[EASY] Directory is created during deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,15 @@ install: docs
 set_oauth2_config:
 	cat ./oauth2_config.json | ./scripts/set_secret.py --secret-name oauth2_config
 
+check_directory_schema:
+	./scripts/upgrade_schema.py
+
+upgrade_published_schema:
+	./scripts/upgrade_schema.py --upgrade-published
+
+upgrade_directory_schema:
+	./scripts/upgrade_schema.py --upgrade-directory
+
 plan-infra:
 	$(MAKE) -C infra plan-all
 
@@ -46,7 +55,10 @@ package:
 	rm ./chalicelib/service_config.json
 	cp -R ./fusillade ./policies ./service_config.json chalicelib
 
-deploy: package
+setup_directory:
+	./scripts/make_directory.py
+
+deploy: package setup_directory
 	./build_chalice_config.sh $(FUS_DEPLOYMENT_STAGE)
 	chalice deploy --no-autogen-policy --stage $(FUS_DEPLOYMENT_STAGE) --api-gateway-stage $(FUS_DEPLOYMENT_STAGE)
 

--- a/fusillade/__init__.py
+++ b/fusillade/__init__.py
@@ -1,29 +1,4 @@
-from .errors import FusilladeException, FusilladeBindingException
 from .config import Config
+from . import logging
 from .clouddirectory import User, Group, Role, CloudDirectory
-from fusillade import logging
-
-'''
-system config:
-- directory schema
-
-service config:
-- provisioning policy
-'''
-
-
-def get_directory():
-    directory_name = Config.get_directory_name()
-    try:
-        _directory = CloudDirectory.from_name(directory_name)
-    except FusilladeException:
-        from .clouddirectory import publish_schema, create_directory
-        schema_name = Config.get_schema_name()
-        schema_arn = publish_schema(schema_name, **Config.directory_schema_version)
-        admins = Config.get_admin_emails()
-        _directory = create_directory(directory_name, schema_arn, admins)
-    return _directory
-
-
-directory = get_directory()
-# TODO: change the deployment to be in a separate file
+from .errors import FusilladeException, FusilladeBindingException

--- a/fusillade/api/evaluate.py
+++ b/fusillade/api/evaluate.py
@@ -1,10 +1,10 @@
-from threading import Thread
-from concurrent.futures import Future
 import typing
+from concurrent.futures import Future
+from threading import Thread
 
 from flask import make_response, jsonify
 
-from fusillade import User, directory
+from fusillade import User
 from fusillade.utils.authorize import assert_authorized, evaluate_policy
 
 
@@ -12,7 +12,7 @@ def evaluate_policy_api(token_info, body):
     with AuthorizeThread(token_info['https://auth.data.humancellatlas.org/email'],
                          ['fus:Evaluate'],
                          ['arn:hca:fus:*:*:user']):
-        policies = User(directory, body['principal']).lookup_policies()
+        policies = User(body['principal']).lookup_policies()
         result = evaluate_policy(body['principal'], body['action'], body['resource'], policies)
     return make_response(jsonify(**body, result=result), 200)
 
@@ -22,6 +22,7 @@ class AuthorizeThread:
     Authorize the requester in a separate thread while executing the request. This is safe only when performing
     read operations. If authorization fails a 403 is returned and the original request results are discarded.
     """
+
     def __init__(
             self,
             user: str,

--- a/fusillade/api/groups/__init__.py
+++ b/fusillade/api/groups/__init__.py
@@ -1,6 +1,6 @@
 from flask import request, make_response, jsonify
 
-from fusillade import directory, Group
+from fusillade import Group
 from fusillade.api.paging import get_next_token, get_page
 from fusillade.utils.authorize import authorize
 
@@ -8,7 +8,7 @@ from fusillade.utils.authorize import authorize
 @authorize(['fus:PostGroup'], ['arn:hca:fus:*:*:group'])
 def post_group(token_info: dict):
     json_body = request.json
-    group = Group.create(directory, json_body['group_id'], statement=json_body.get('policy'),
+    group = Group.create(json_body['group_id'], statement=json_body.get('policy'),
                          creator=token_info['https://auth.data.humancellatlas.org/email'])
     group.add_roles(json_body.get('roles', []))  # Determine what response to return if roles don't exist
     return make_response(f"New role {json_body['group_id']} created.", 201)
@@ -17,18 +17,18 @@ def post_group(token_info: dict):
 @authorize(['fus:GetGroup'], ['arn:hca:fus:*:*:group'])
 def get_groups(token_info: dict):
     next_token, per_page = get_next_token(request.args)
-    return get_page(Group.list_all, next_token, per_page, directory)
+    return get_page(Group.list_all, next_token, per_page)
 
 
 @authorize(['fus:GetGroup'], ['arn:hca:fus:*:*:group/{group_id}/'], ['group_id'], {'fus:group_id': 'group_id'})
 def get_group(token_info: dict, group_id: str):
-    group = Group(directory, group_id)
+    group = Group(group_id)
     return make_response(jsonify(group.get_info()), 200)
 
 
 @authorize(['fus:PutGroup'], ['arn:hca:fus:*:*:group/{group_id}/policy'], ['group_id'], {'fus:group_id': 'group_id'})
 def put_group_policy(token_info: dict, group_id: str):
-    group = Group(directory, group_id)
+    group = Group(group_id)
     group.set_policy(request.json['policy'])
     return make_response(f"{group_id} policy modified.", 200)
 
@@ -36,20 +36,20 @@ def put_group_policy(token_info: dict, group_id: str):
 @authorize(['fus:GetUser'], ['arn:hca:fus:*:*:group/{group_id}/users'], ['group_id'], {'fus:group_id': 'group_id'})
 def get_group_users(token_info: dict, group_id: str):
     next_token, per_page = get_next_token(request.args)
-    group = Group(directory, group_id)
+    group = Group(group_id)
     return get_page(group.get_users_page, next_token, per_page)
 
 
 @authorize(['fus:GetRole'], ['arn:hca:fus:*:*:group/{group_id}/roles'], ['group_id'], {'fus:group_id': 'group_id'})
 def get_groups_roles(token_info: dict, group_id: str):
     next_token, per_page = get_next_token(request.args)
-    group = Group(directory, group_id)
+    group = Group(group_id)
     return get_page(group.get_roles, next_token, per_page)
 
 
 @authorize(['fus:PutRole'], ['arn:hca:fus:*:*:group/{group_id}/roles'], ['group_id'], {'fus:group_id': 'group_id'})
 def put_groups_roles(token_info: dict, group_id: str):
-    group = Group(directory, group_id)
+    group = Group(group_id)
     action = request.args['action']
     if action == 'add':
         group.add_roles(request.json['roles'])

--- a/fusillade/api/internal.py
+++ b/fusillade/api/internal.py
@@ -2,8 +2,8 @@ import requests
 from connexion.lifecycle import ConnexionResponse
 from flask import request
 from furl import furl
+
 from fusillade.config import Config
-from fusillade import directory
 
 
 def version():
@@ -21,7 +21,7 @@ def version():
 
 def health_check(*args, **kwargs):
     health_checks = dict()
-    health_checks.update(**directory.get_health_status(),
+    health_checks.update(**Config.get_directory().get_health_status(),
                          **get_openip_health_status())
     if all([check == 'ok' for check in health_checks.values()]):
         body = dict(

--- a/fusillade/api/roles/__init__.py
+++ b/fusillade/api/roles/__init__.py
@@ -1,6 +1,6 @@
 from flask import request, make_response, jsonify
 
-from fusillade import Role, directory
+from fusillade import Role
 from fusillade.api.paging import get_next_token, get_page
 from fusillade.utils.authorize import authorize
 
@@ -8,7 +8,7 @@ from fusillade.utils.authorize import authorize
 @authorize(['fus:PostRole'], ['arn:hca:fus:*:*:role'])
 def post_role(token_info: dict):
     json_body = request.json
-    Role.create(directory, json_body['role_id'], statement=json_body.get('policy'),
+    Role.create(json_body['role_id'], statement=json_body.get('policy'),
                 creator=token_info['https://auth.data.humancellatlas.org/email'])
     return make_response(f"New role {json_body['role_id']} created.", 201)
 
@@ -16,17 +16,17 @@ def post_role(token_info: dict):
 @authorize(['fus:GetRole'], ['arn:hca:fus:*:*:role'])
 def get_roles(token_info: dict):
     next_token, per_page = get_next_token(request.args)
-    return get_page(Role.list_all, next_token, per_page, directory)
+    return get_page(Role.list_all, next_token, per_page)
 
 
 @authorize(['fus:GetRole'], ['arn:hca:fus:*:*:role/{role_id}/'], ['role_id'])
 def get_role(token_info: dict, role_id: str):
-    role = Role(directory, role_id)
+    role = Role(role_id)
     return make_response(jsonify(role.get_info()), 200)
 
 
 @authorize(['fus:PutRole'], ['arn:hca:fus:*:*:role/{role_id}/'], ['role_id'])
 def put_role_policy(token_info: dict, role_id: str):
-    role = Role(directory, role_id)
+    role = Role(role_id)
     role.set_policy(request.json['policy'])
     return make_response('Role policy updated.', 200)

--- a/fusillade/api/users/__init__.py
+++ b/fusillade/api/users/__init__.py
@@ -1,6 +1,6 @@
 from flask import request, make_response, jsonify
 
-from fusillade import User, directory
+from fusillade import User
 from fusillade.api.paging import get_next_token, get_page
 from fusillade.utils.authorize import authorize
 
@@ -8,7 +8,7 @@ from fusillade.utils.authorize import authorize
 @authorize(['fus:PostUser'], ['arn:hca:fus:*:*:user'])
 def post_user(token_info: dict):
     json_body = request.json
-    user = User.provision_user(directory, json_body['user_id'], statement=json_body.get('policy'),
+    user = User.provision_user(json_body['user_id'], statement=json_body.get('policy'),
                                creator=token_info['https://auth.data.humancellatlas.org/email'])
     user.add_roles(json_body.get('roles', []))
     user.add_groups(json_body.get('groups', []))
@@ -18,18 +18,18 @@ def post_user(token_info: dict):
 @authorize(['fus:GetUser'], ['arn:hca:fus:*:*:user'])
 def get_users(token_info: dict):
     next_token, per_page = get_next_token(request.args)
-    return get_page(User.list_all, next_token, per_page, directory)
+    return get_page(User.list_all, next_token, per_page)
 
 
 @authorize(['fus:GetUser'], ['arn:hca:fus:*:*:user/{user_id}/'], ['user_id'])
 def get_user(token_info: dict, user_id: str):
-    user = User(directory, user_id)
+    user = User(user_id)
     return make_response(jsonify(user.get_info()), 200)
 
 
 @authorize(['fus:PutUser'], ['arn:hca:fus:*:*:user/{user_id}/status'], ['user_id'])
 def put_user(token_info: dict, user_id: str):
-    user = User(directory, user_id)
+    user = User(user_id)
     new_status = request.args['status']
     if new_status == 'enabled':
         user.enable()
@@ -45,7 +45,7 @@ def put_user(token_info: dict, user_id: str):
 @authorize(['fus:GetUser'], ['arn:hca:fus:*:*:user/{user_id}/owns'], ['user_id'])
 def get_users_owns(token_info: dict, user_id: str):
     next_token, per_page = get_next_token(request.args)
-    user = User(directory, user_id)
+    user = User(user_id)
     return get_page(user.get_owned,
                     next_token,
                     per_page,
@@ -55,7 +55,7 @@ def get_users_owns(token_info: dict, user_id: str):
 
 @authorize(['fus:PutUser'], ['arn:hca:fus:*:*:user/{user_id}/policy'], ['user_id'])
 def put_user_policy(token_info: dict, user_id: str):
-    user = User(directory, user_id)
+    user = User(user_id)
     user.set_policy(request.json['policy'])
     return make_response('', 200)
 
@@ -63,13 +63,13 @@ def put_user_policy(token_info: dict, user_id: str):
 @authorize(['fus:GetGroup'], ['arn:hca:fus:*:*:user/{user_id}/groups'], ['user_id'])
 def get_users_groups(token_info: dict, user_id: str):
     next_token, per_page = get_next_token(request.args)
-    user = User(directory, user_id)
+    user = User(user_id)
     return get_page(user.get_groups, next_token, per_page)
 
 
 @authorize(['fus:PutGroup'], ['arn:hca:fus:*:*:user/{user_id}/groups'], ['user_id'])
 def put_users_groups(token_info: dict, user_id: str):
-    user = User(directory, user_id)
+    user = User(user_id)
     action = request.args['action']
     if action == 'add':
         user.add_groups(request.json['groups'])
@@ -81,13 +81,13 @@ def put_users_groups(token_info: dict, user_id: str):
 @authorize(['fus:GetRole'], ['arn:hca:fus:*:*:user/{user_id}/roles'], ['user_id'])
 def get_users_roles(token_info: dict, user_id: str):
     next_token, per_page = get_next_token(request.args)
-    user = User(directory, user_id)
+    user = User(user_id)
     return get_page(user.get_roles, next_token, per_page)
 
 
 @authorize(['fus:PutRole'], ['arn:hca:fus:*:*:user/{user_id}/roles'], ['user_id'])
 def put_users_roles(token_info: dict, user_id: str):
-    user = User(directory, user_id)
+    user = User(user_id)
     action = request.args['action']
     if action == 'add':
         user.add_roles(request.json['roles'])

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -118,6 +118,7 @@ def create_directory(name: str, schema: str, admins: List[str]) -> 'CloudDirecto
         )
     except cd_client.exceptions.DirectoryAlreadyExistsException:
         directory = CloudDirectory.from_name(name)
+        return directory
     else:
         # create structure
         for folder_name in ('group', 'user', 'role', 'policy'):
@@ -132,8 +133,8 @@ def create_directory(name: str, schema: str, admins: List[str]) -> 'CloudDirecto
         for admin in admins:
             User.provision_user(admin, roles=['fusillade_admin'])
         User.provision_user('public')
-    finally:
         return directory
+
 
 
 def _paging_loop(fn: Callable, key: str, upack_response: Optional[Callable] = None, **kwarg):

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -136,7 +136,6 @@ def create_directory(name: str, schema: str, admins: List[str]) -> 'CloudDirecto
         return directory
 
 
-
 def _paging_loop(fn: Callable, key: str, upack_response: Optional[Callable] = None, **kwarg):
     while True:
         resp = fn(**kwarg)

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -17,6 +17,7 @@ from typing import Iterator, Any, Tuple, Dict, List, Callable, Optional, Union, 
 
 from dcplib.aws import clients as aws_clients
 
+from fusillade import Config
 from fusillade.errors import FusilladeException, FusilladeHTTPException, FusilladeNotFoundException
 from fusillade.utils.retry import retry
 
@@ -123,14 +124,14 @@ def create_directory(name: str, schema: str, admins: List[str]) -> 'CloudDirecto
             directory.create_folder('/', folder_name)
 
         # create roles
-        Role.create(directory, "default_user", statement=get_json_file(default_user_role_path))
-        Role.create(directory, "fusillade_admin", statement=get_json_file(default_admin_role_path))
-        Group.create(directory, "user_default").add_roles(['default_user'])
+        Role.create("default_user", statement=get_json_file(default_user_role_path))
+        Role.create("fusillade_admin", statement=get_json_file(default_admin_role_path))
+        Group.create("user_default").add_roles(['default_user'])
 
         # create admins
         for admin in admins:
-            User.provision_user(directory, admin, roles=['fusillade_admin'])
-        User.provision_user(directory, 'public')
+            User.provision_user(admin, roles=['fusillade_admin'])
+        User.provision_user('public')
     finally:
         return directory
 
@@ -891,26 +892,24 @@ class CloudNode:
     allowed_policy_types = ('IAMPolicy',)
 
     def __init__(self,
-                 cloud_directory: CloudDirectory,
                  name: str = None,
                  object_ref: str = None):
         """
 
-        :param cloud_directory:
         :param name:
         :param object_ref:
         """
+        self.cd: CloudDirectory = Config.get_directory()
         if name and object_ref:
             raise FusilladeException("object_reference XOR name")
         if name:
             self._name: str = name
             self._path_name: str = self.hash_name(name)
-            self.object_ref: str = cloud_directory.get_obj_type_path(self.object_type) + self._path_name
+            self.object_ref: str = self.cd.get_obj_type_path(self.object_type) + self._path_name
         else:
             self._name: str = None
             self._path_name: str = None
             self.object_ref: str = object_ref
-        self.cd: CloudDirectory = cloud_directory
         self.attached_policies: Dict[str, str] = dict()
 
     @staticmethod
@@ -1083,12 +1082,13 @@ class CloudNode:
         return dict([(attr['Key']['Name'], attr['Value'].popitem()[1]) for attr in resp['Attributes']])
 
     @classmethod
-    def list_all(cls, directory: CloudDirectory, next_token: str, per_page: int):
-        resp, next_token = directory.list_object_children_paged(f'/{cls.object_type}/', next_token, per_page)
-        operations = [directory.batch_get_attributes(f'${obj_ref}', cls._facet, ['name'])
+    def list_all(cls, next_token: str, per_page: int):
+        cd = Config.get_directory()
+        resp, next_token = cd.list_object_children_paged(f'/{cls.object_type}/', next_token, per_page)
+        operations = [cd.batch_get_attributes(f'${obj_ref}', cls._facet, ['name'])
                       for obj_ref in resp.values()]
         results = []
-        for r in directory.batch_read(operations)['Responses']:
+        for r in cd.batch_read(operations)['Responses']:
             if r.get('SuccessfulResponse'):
                 results.append(
                     r.get('SuccessfulResponse')['GetObjectAttributes']['Attributes'][0]['Value']['StringValue'])
@@ -1267,21 +1267,21 @@ class CreateMixin(PolicyMixin):
     """Adds creation support to a cloudNode"""
 
     @classmethod
-    def create(cls, cloud_directory: CloudDirectory, name: str, statement: Optional[str] = None,
+    def create(cls, name: str, statement: Optional[str] = None,
                creator=None) -> Type['CloudNode']:
         if not statement:
             statement = get_json_file(cls._default_policy_path)
         cls._verify_statement(statement)
         _creator = creator if creator else "fusillade"
         try:
-            cloud_directory.create_object(cls.hash_name(name), cls._facet, name=name, obj_type=cls.object_type,
-                                          created_by=_creator)
+            Config.get_directory().create_object(cls.hash_name(name), cls._facet, name=name, obj_type=cls.object_type,
+                                                 created_by=_creator)
         except cd_client.exceptions.LinkNameAlreadyInUseException:
             raise FusilladeHTTPException(
                 status=409, title="Conflict", detail=f"The {cls.object_type} named {name} already exists.")
-        new_node = cls(cloud_directory, name)
+        new_node = cls(name)
         if creator:
-            User(cloud_directory, name=creator).add_ownership(new_node)
+            User(name=creator).add_ownership(new_node)
         logger.info(dict(message=f"{cls.object_type} created by {_creator}",
                          object=dict(type=new_node.object_type, path_name=new_node._path_name)))
         new_node._set_policy_with_retry(statement)
@@ -1397,14 +1397,12 @@ class User(CloudNode, RolesMixin, PolicyMixin, OwnershipMixin):
     _facet = 'LeafFacet'
     object_type = 'user'
 
-    def __init__(self, cloud_directory: CloudDirectory, name: str = None, object_ref: str = None):
+    def __init__(self, name: str = None, object_ref: str = None):
         """
 
-        :param cloud_directory:
         :param name:
         """
-        super(User, self).__init__(cloud_directory,
-                                   name=name,
+        super(User, self).__init__(name=name,
                                    object_ref=object_ref)
         self._status = None
         self._groups: Optional[List[str]] = None
@@ -1414,7 +1412,7 @@ class User(CloudNode, RolesMixin, PolicyMixin, OwnershipMixin):
         try:
             policy_paths = self.lookup_policies_batched()
         except cd_client.exceptions.ResourceNotFoundException:
-            self.provision_user(self.cd, self.name)
+            self.provision_user(self.name)
             policy_paths = self.lookup_policies_batched()
         return self.cd.get_policies(policy_paths)
 
@@ -1471,7 +1469,6 @@ class User(CloudNode, RolesMixin, PolicyMixin, OwnershipMixin):
     @classmethod
     def provision_user(
             cls,
-            cloud_directory: CloudDirectory,
             name: str,
             statement: Optional[str] = None,
             roles: List[str] = None,
@@ -1481,14 +1478,13 @@ class User(CloudNode, RolesMixin, PolicyMixin, OwnershipMixin):
         """
         Creates a user in cloud directory if the users does not already exists.
 
-        :param cloud_directory:
         :param name:
         :param statement:
         :param roles:
         :param groups:
         :return:
         """
-        user = cls(cloud_directory, name)
+        user = cls(name)
         _creator = creator if creator else "fusillade"
         try:
             user.cd.create_object(user._path_name,
@@ -1577,13 +1573,12 @@ class Group(CloudNode, RolesMixin, CreateMixin, OwnershipMixin):
     object_type = 'group'
     _default_policy_path = default_group_policy_path
 
-    def __init__(self, cloud_directory: CloudDirectory, name: str = None, object_ref: str = None):
+    def __init__(self, name: str = None, object_ref: str = None):
         """
 
-        :param cloud_directory:
         :param name:
         """
-        super(Group, self).__init__(cloud_directory, name=name, object_ref=object_ref)
+        super(Group, self).__init__(name=name, object_ref=object_ref)
         self._groups: Optional[List[str]] = None
         self._roles: Optional[List[str]] = None
 
@@ -1638,7 +1633,7 @@ class Group(CloudNode, RolesMixin, CreateMixin, OwnershipMixin):
         :return:
         """
         for user in users:
-            User(self.cd, user).remove_groups([self._path_name])
+            User(user).remove_groups([self._path_name])
         logger.info(dict(message="Removing users from group",
                          object=dict(type=self.object_type, path_name=self._path_name),
                          users=[user for user in users]))
@@ -1657,8 +1652,8 @@ class Role(CloudNode, CreateMixin):
     object_type: str = 'role'
     _default_policy_path: str = default_role_path
 
-    def __init__(self, cloud_directory: CloudDirectory, name: str = None, object_ref: str = None):
-        super(Role, self).__init__(cloud_directory, name=name, object_ref=object_ref)
+    def __init__(self, name: str = None, object_ref: str = None):
+        super(Role, self).__init__(name=name, object_ref=object_ref)
 
     def get_info(self):
         info = super(Role, self).get_info()

--- a/fusillade/config.py
+++ b/fusillade/config.py
@@ -14,8 +14,7 @@ class Config:
     _openid_provider = None
     version = "unversioned"
     directory_schema_version = {"Version": '0', "MinorVersion": '0'}
-
-    # TODO make configurable
+    _directory = None
 
     @classmethod
     def get_admin_emails(cls):
@@ -33,6 +32,14 @@ class Config:
                     SecretId=f"{os.environ['FUS_SECRETS_STORE']}/"
                     f"{os.environ['FUS_DEPLOYMENT_STAGE']}/oauth2_config")["SecretString"])
         return cls._oauth2_config
+
+    @classmethod
+    def get_directory(cls):
+        if not cls._directory:
+            from fusillade import CloudDirectory
+            directory_name = cls.get_directory_name()
+            cls._directory = CloudDirectory.from_name(directory_name)
+        return cls._directory
 
     @classmethod
     def get_directory_name(cls):

--- a/fusillade/config.py
+++ b/fusillade/config.py
@@ -15,6 +15,7 @@ class Config:
     version = "unversioned"
     directory_schema_version = {"Version": '0', "MinorVersion": '0'}
     _directory = None
+    _directory_name = None
 
     @classmethod
     def get_admin_emails(cls):
@@ -43,7 +44,9 @@ class Config:
 
     @classmethod
     def get_directory_name(cls):
-        return os.getenv("FUSILLADE_DIR", f"hca_fusillade_{os.environ['FUS_DEPLOYMENT_STAGE']}")
+        if not cls._directory_name:
+            cls._directory_name = os.getenv("FUSILLADE_DIR", f"hca_fusillade_{os.environ['FUS_DEPLOYMENT_STAGE']}")
+        return cls._directory_name
 
     @classmethod
     def get_schema_name(cls):

--- a/fusillade/utils/authorize.py
+++ b/fusillade/utils/authorize.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Optional, Any
 
 from dcplib.aws import clients as aws_clients
 
-from fusillade import User, directory
+from fusillade import User
 from fusillade.errors import FusilladeForbiddenException
 
 logger = logging.getLogger(__name__)
@@ -52,7 +52,7 @@ def assert_authorized(user, actions, resources, context_entries=None):
     :param context_entries:
     :return:
     """
-    u = User(directory, user)
+    u = User(user)
     policies = u.lookup_policies()
     _context_entries = [
         {

--- a/scripts/make_directory.py
+++ b/scripts/make_directory.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from fusillade.clouddirectory import publish_schema, create_directory
+from fusillade import Config
+
+
+def setup_clouddirectory():
+    schema_name = Config.get_schema_name()
+    schema_arn = publish_schema(schema_name, **Config.directory_schema_version)
+    admins = Config.get_admin_emails()
+    directory_name = Config.get_directory_name()
+    return create_directory(directory_name, schema_arn, admins)
+
+
+if __name__ == "__main__":
+    setup_clouddirectory()

--- a/tests/base_api_test.py
+++ b/tests/base_api_test.py
@@ -3,15 +3,14 @@ import os
 
 from furl import furl
 
-from tests import random_hex_string
+from tests.common import service_accounts, new_test_directory
 from tests.infra.testmode import is_integration
 
 if not is_integration():
     old_directory_name = os.getenv("FUSILLADE_DIR", None)
-    os.environ["FUSILLADE_DIR"] = "test_api_" + random_hex_string()
+    new_test_directory()
 
-from tests.common import service_accounts
-from fusillade import directory, Config
+from fusillade import Config
 from fusillade.clouddirectory import cleanup_directory, User
 
 
@@ -20,7 +19,7 @@ class BaseAPITest():
     @classmethod
     def setUpClass(cls):
         try:
-            User.provision_user(directory, service_accounts['admin']['client_email'], roles=['fusillade_admin'])
+            User.provision_user(service_accounts['admin']['client_email'], roles=['fusillade_admin'])
         except Exception:
             pass
 
@@ -35,14 +34,14 @@ class BaseAPITest():
     @staticmethod
     def clear_directory(**kwargs):
         kwargs["users"] = kwargs.get('users', []) + [*Config.get_admin_emails()]
-        directory.clear(**kwargs)
+        Config.get_directory().clear(**kwargs)
 
     @classmethod
     def tearDownClass(cls):
         cls.clear_directory()
 
         if not is_integration():
-            cleanup_directory(directory._dir_arn)
+            cleanup_directory(Config.get_directory()._dir_arn)
             if old_directory_name:
                 os.environ["FUSILLADE_DIR"] = old_directory_name
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -58,9 +58,10 @@ def create_test_statements(length=1):
     return json.dumps(statement)
 
 
-def new_test_directory(directory_name=None) -> typing.Tuple[CloudDirectory, str]:
+def new_test_directory(directory_name=None) -> typing.Tuple[CloudDirectory, str, str]:
     directory_name = directory_name if directory_name else "test_dir_" + random_hex_string()
     schema_arn = publish_schema(schema_name, 'T' + random_hex_string())
+    os.environ["FUSILLADE_DIR"] = directory_name
     directory = create_directory(directory_name, schema_arn, [service_accounts['admin']['client_email']])
     return directory, schema_arn
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -61,6 +61,8 @@ def create_test_statements(length=1):
 def new_test_directory(directory_name=None) -> typing.Tuple[CloudDirectory, str, str]:
     directory_name = directory_name if directory_name else "test_dir_" + random_hex_string()
     schema_arn = publish_schema(schema_name, 'T' + random_hex_string())
+    Config._directory = None
+    Config._directory_name = None
     os.environ["FUSILLADE_DIR"] = directory_name
     directory = create_directory(directory_name, schema_arn, [service_accounts['admin']['client_email']])
     return directory, schema_arn

--- a/tests/test_clouddirectory.py
+++ b/tests/test_clouddirectory.py
@@ -1,5 +1,6 @@
+import os
+import sys
 import unittest
-import os, sys
 from unittest import mock
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
@@ -54,7 +55,7 @@ class TestCloudDirectory(unittest.TestCase):
         """Check that cloud directory is setup for fusillade"""
         schema_name = "authz"
         schema_version = random_hex_string()
-        directory_name = "test_dir_" + random_hex_string()
+        os.environ["FUSILLADE_DIR"] = directory_name = "test_dir_" + random_hex_string()
         schema_arn = publish_schema(schema_name, schema_version)
         self.addCleanup(cleanup_schema, schema_arn)
         directory = create_directory(directory_name, schema_arn, [service_accounts['admin']['client_email']])
@@ -101,9 +102,6 @@ class TestCloudDirectory(unittest.TestCase):
             for tag in expected_tags:
                 with self.subTest(f"Directory has {tag} tag when created"):
                     self.assertIn(tag, response['Tags'])
-
-
-
 
 
 if __name__ == '__main__':

--- a/tests/test_clouddirectory.py
+++ b/tests/test_clouddirectory.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import unittest
-from unittest import mock
 from unittest.mock import patch
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -17,7 +16,7 @@ admin_email = "test_email1@domain.com,test_email2@domain.com, test_email3@domain
 @standalone
 class TestCloudDirectory(unittest.TestCase):
 
-    @patch.object(Config, '_directory_name', "test_dir_" + random_hex_string())
+    @patch.dict(os.environ, FUSILLADE_DIR="test_dir_" + random_hex_string())
     def test_cd(self):
         """ Testing the process of creating and destroying an AWS CloudDirectory"""
         schema_name = "authz"
@@ -51,8 +50,8 @@ class TestCloudDirectory(unittest.TestCase):
         with self.subTest("error returned when deleting a nonexistent schema."):
             self.assertRaises(cd_client.exceptions.ResourceNotFoundException, cleanup_schema, schema_arn_2)
 
-    @mock.patch.dict(os.environ, FUS_ADMIN_EMAILS=admin_email)
-    @patch.object(Config, '_directory_name', "test_dir_" + random_hex_string())
+    @patch.dict(os.environ, FUS_ADMIN_EMAILS=admin_email)
+    @patch.dict(os.environ, FUSILLADE_DIR="test_dir_" + random_hex_string())
     def test_structure(self):
         """Check that cloud directory is setup for fusillade"""
         schema_name = "authz"

--- a/tests/test_clouddirectory.py
+++ b/tests/test_clouddirectory.py
@@ -2,6 +2,7 @@ import os
 import sys
 import unittest
 from unittest.mock import patch
+
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
@@ -10,13 +11,14 @@ from tests.common import random_hex_string, service_accounts
 from fusillade.clouddirectory import cd_client, cleanup_directory, cleanup_schema, publish_schema, create_directory, \
     CloudDirectory, CloudNode
 from fusillade import Config
+
 admin_email = "test_email1@domain.com,test_email2@domain.com, test_email3@domain.com "
 
 
 @standalone
 class TestCloudDirectory(unittest.TestCase):
 
-    @patch.dict(os.environ, FUSILLADE_DIR="test_dir_" + random_hex_string())
+    @patch.dict(os.environ, {'FUSILLADE_DIR': "test_dir_" + random_hex_string()})
     def test_cd(self):
         """ Testing the process of creating and destroying an AWS CloudDirectory"""
         schema_name = "authz"
@@ -50,23 +52,24 @@ class TestCloudDirectory(unittest.TestCase):
         with self.subTest("error returned when deleting a nonexistent schema."):
             self.assertRaises(cd_client.exceptions.ResourceNotFoundException, cleanup_schema, schema_arn_2)
 
-    @patch.dict(os.environ, FUS_ADMIN_EMAILS=admin_email)
-    @patch.dict(os.environ, FUSILLADE_DIR="test_dir_" + random_hex_string())
+    @patch.dict(os.environ, {'FUSILLADE_DIR': "test_dir_" + random_hex_string(),
+                             'FUS_ADMIN_EMAILS': admin_email})
     def test_structure(self):
         """Check that cloud directory is setup for fusillade"""
         schema_name = "authz"
         schema_version = random_hex_string()
-        directory_name = Config.get_directory_name()
+        directory_name = os.environ["FUSILLADE_DIR"]
         schema_arn = publish_schema(schema_name, schema_version)
         self.addCleanup(cleanup_schema, schema_arn)
-        Config._direcory = create_directory(directory_name, schema_arn, [service_accounts['admin']['client_email']])
-        directory = Config.get_directory()
+        Config._directory_name = None
+        Config._directory = None
+        directory = create_directory(directory_name, schema_arn, [service_accounts['admin']['client_email']])
         self.addCleanup(cleanup_directory, CloudDirectory.from_name(directory_name)._dir_arn)
 
         folders = ['user', 'role', 'group', 'policy']
         for folder in folders:
             with self.subTest(f"{folder} node is created when directory is created"):
-                resp = Config.get.get_object_information(f'/{folder}')
+                resp = directory.get_object_information(f'/{folder}')
                 self.assertTrue(resp['ObjectIdentifier'])
 
         roles = [f"/role/{CloudNode.hash_name(name)}" for name in ['fusillade_admin', 'default_user']]

--- a/tests/test_clouddirectory.py
+++ b/tests/test_clouddirectory.py
@@ -56,16 +56,17 @@ class TestCloudDirectory(unittest.TestCase):
         """Check that cloud directory is setup for fusillade"""
         schema_name = "authz"
         schema_version = random_hex_string()
-        directory_name = os.environ["FUSILLADE_DIR"]
+        directory_name = Config.get_directory_name()
         schema_arn = publish_schema(schema_name, schema_version)
         self.addCleanup(cleanup_schema, schema_arn)
-        directory = create_directory(directory_name, schema_arn, [service_accounts['admin']['client_email']])
+        Config._direcory = create_directory(directory_name, schema_arn, [service_accounts['admin']['client_email']])
+        directory = Config.get_directory()
         self.addCleanup(cleanup_directory, CloudDirectory.from_name(directory_name)._dir_arn)
 
         folders = ['user', 'role', 'group', 'policy']
         for folder in folders:
             with self.subTest(f"{folder} node is created when directory is created"):
-                resp = directory.get_object_information(f'/{folder}')
+                resp = Config.get.get_object_information(f'/{folder}')
                 self.assertTrue(resp['ObjectIdentifier'])
 
         roles = [f"/role/{CloudNode.hash_name(name)}" for name in ['fusillade_admin', 'default_user']]

--- a/tests/test_group_api.py
+++ b/tests/test_group_api.py
@@ -16,7 +16,6 @@ sys.path.insert(0, pkg_root)  # noqa
 from tests.base_api_test import BaseAPITest
 from tests.common import get_auth_header, service_accounts, create_test_statement
 from tests.data import TEST_NAMES_NEG, TEST_NAMES_POS
-from fusillade import directory
 from fusillade.clouddirectory import Role, Group, User
 
 

--- a/tests/test_group_api.py
+++ b/tests/test_group_api.py
@@ -42,7 +42,7 @@ class TestGroupApi(BaseAPITest, unittest.TestCase):
                 'name': f'201 returned when creating a group with role only',
                 'json_request_body': {
                     "group_id": "Group1",
-                    "roles": [Role.create(directory, "role_02").name]
+                    "roles": [Role.create( "role_02").name]
                 },
                 'response': {
                     'code': 201
@@ -62,7 +62,7 @@ class TestGroupApi(BaseAPITest, unittest.TestCase):
                 'name': f'201 returned when creating a group with role and policy',
                 'json_request_body': {
                     "group_id": "Group3",
-                    "roles": [Role.create(directory, "role_04").name],
+                    "roles": [Role.create( "role_04").name],
                     "policy": create_test_statement("policy_04")
                 },
                 'response': {
@@ -72,7 +72,7 @@ class TestGroupApi(BaseAPITest, unittest.TestCase):
             {
                 'name': f'400 returned when creating a group without group_id',
                 'json_request_body': {
-                    "roles": [Role.create(directory, "role_05").name],
+                    "roles": [Role.create( "role_05").name],
                     "policy": create_test_statement("policy_05")
                 },
                 'response': {
@@ -127,7 +127,7 @@ class TestGroupApi(BaseAPITest, unittest.TestCase):
         name = "Groupx"
         resp = self.app.get(f'/v1/group/{name}/', headers=headers)
         self.assertEqual(404, resp.status_code)
-        Group.create(directory,name)
+        Group.create(name)
         resp = self.app.get(f'/v1/group/{name}/', headers=headers)
         self.assertEqual(name, json.loads(resp.body)['group_id'])
         self.assertTrue(json.loads(resp.body)['policies'])
@@ -152,7 +152,7 @@ class TestGroupApi(BaseAPITest, unittest.TestCase):
                 'group_id': "Group1",
                 'action': 'add',
                 'json_request_body': {
-                    "roles": [Role.create(directory, "role_0").name]
+                    "roles": [Role.create( "role_0").name]
                 },
                 'response': {
                     'code': 200
@@ -162,7 +162,7 @@ class TestGroupApi(BaseAPITest, unittest.TestCase):
                 'group_id': "Group2",
                 'action': 'remove',
                 'json_request_body': {
-                    "roles": [Role.create(directory, "role_1").name]
+                    "roles": [Role.create( "role_1").name]
                 },
                 'response': {
                     'code': 200
@@ -180,7 +180,7 @@ class TestGroupApi(BaseAPITest, unittest.TestCase):
                     'action': test['action']
                 }
                 url.add(query_params=query_params)
-                group = Group.create(directory, test['group_id'])
+                group = Group.create( test['group_id'])
                 if test['action'] == 'remove':
                     group.add_roles(test['json_request_body']['roles'])
                 resp = self.app.put(url.url, headers=headers, data=data)
@@ -191,11 +191,11 @@ class TestGroupApi(BaseAPITest, unittest.TestCase):
         headers.update(get_auth_header(service_accounts['admin']))
         name = "Group1"
         key = 'roles'
-        group = Group.create(directory,name)
+        group = Group.create(name)
         resp = self.app.get(f'/v1/group/{name}/roles', headers=headers)
-        group_role_names = [Role(directory, None, role).name for role in group.roles]
+        group_role_names = [Role( None, role).name for role in group.roles]
         self.assertEqual(0, len(json.loads(resp.body)[key]))
-        roles = [Role.create(directory, f"role_{i}").name for i in range(10)]
+        roles = [Role.create( f"role_{i}").name for i in range(10)]
         group.add_roles(roles)
         self._test_paging(f'/v1/group/{name}/roles', headers, 5, key)
 
@@ -204,11 +204,11 @@ class TestGroupApi(BaseAPITest, unittest.TestCase):
         headers.update(get_auth_header(service_accounts['admin']))
         name = "Group1"
         key = 'users'
-        group = Group.create(directory,name)
+        group = Group.create(name)
         resp = self.app.get(f'/v1/group/{name}/users', headers=headers)
-        group_user_names = [User(directory,user).name for user in group.get_users_iter()]
+        group_user_names = [User(user).name for user in group.get_users_iter()]
         self.assertEqual(0, len(json.loads(resp.body)[key]))
-        users = [User.provision_user(directory, f"user_{i}",groups=[name]).name for i in range(10)]
+        users = [User.provision_user( f"user_{i}",groups=[name]).name for i in range(10)]
         self._test_paging(f'/v1/group/{name}/users', headers, 5, key)
 
     def test_default_group(self):

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -30,22 +30,22 @@ class TestGroup(unittest.TestCase):
     def test_create_group(self):
         with self.subTest("an error is returned when creating a group with an invalid statement."):
             with self.assertRaises(FusilladeHTTPException):
-                group = Group.create(self.directory, "new_group1", "does things")
+                group = Group.create("new_group1", "does things")
 
         with self.subTest("The group is returned when the group has been created with default valid statement"):
-            group = Group.create(self.directory, "new_group2")
+            group = Group.create("new_group2")
             self.assertEqual(group.name,  "new_group2")
             self.assertEqual(group.get_policy(), self.default_group_statement)
 
         with self.subTest("The group is returned when the group has been created with specified valid statement."):
             group_name = "NewGroup1234"
             statement = create_test_statement(group_name)
-            group = Group.create(self.directory, "new_group3", statement)
+            group = Group.create("new_group3", statement)
             self.assertEqual(group.name,  "new_group3")
             self.assertEqual(group.get_policy(), statement)
 
     def test_policy(self):
-        group = Group.create(self.directory, "new_group")
+        group = Group.create("new_group")
         with self.subTest("Only one policy is attached when lookup policy is called on a group without any roles"):
             policies = group.lookup_policies()
             self.assertEqual(len(policies), 1)
@@ -65,23 +65,23 @@ class TestGroup(unittest.TestCase):
 
     def test_users(self):
         emails = ["test@test.com", "why@not.com", "hello@world.com"]
-        users = [User.provision_user(self.directory, email) for email in emails]
+        users = [User.provision_user(email) for email in emails]
         with self.subTest("A user is added to the group when add_users is called"):
-            group = Group.create(self.directory, "test")
-            user = User.provision_user(self.directory, "another@place.com")
+            group = Group.create("test")
+            user = User.provision_user("another@place.com")
             group.add_users([user])
             actual_users = [i for i in group.get_users_iter()]
             self.assertEqual(len(actual_users), 1)
-            self.assertEqual(User(self.directory,object_ref=actual_users[0]).name, user.name)
+            self.assertEqual(User(object_ref=actual_users[0]).name, user.name)
 
         with self.subTest("Multiple users are added to the group when multiple users are passed to add_users"):
-            group = Group.create(self.directory, "test2")
+            group = Group.create("test2")
             group.add_users(users)
             actual_users = [i[1] for i in group.get_users_iter()]
             self.assertEqual(len(actual_users), 3)
 
         with self.subTest("Error returned when a user is added to a group it's already apart of."):
-            group = Group.create(self.directory, "test3")
+            group = Group.create("test3")
             group.add_users(users)
             try:
                 group.add_users(users)
@@ -91,8 +91,8 @@ class TestGroup(unittest.TestCase):
             self.assertEqual(len(actual_users), 3)
 
         with self.subTest("Error returned when adding a user that does not exist"):
-            group = Group.create(self.directory, "test4")
-            user = User(self.directory, "ghost_user@nowhere.com")
+            group = Group.create("test4")
+            user = User("ghost_user@nowhere.com")
             try:
                 group.add_users([user])
             except cd_client.exceptions.BatchWriteException:
@@ -100,9 +100,9 @@ class TestGroup(unittest.TestCase):
 
     def test_roles(self):
         roles = ['role1', 'role2']
-        role_objs = [Role.create(self.directory, name, create_test_statement(name)) for name in roles]
+        role_objs = [Role.create(name, create_test_statement(name)) for name in roles]
         with self.subTest("multiple roles return when multiple roles are attached to group."):
-            group = Group.create(self.directory, "test_roles")
+            group = Group.create("test_roles")
             group.add_roles(roles)
             self.assertEqual(len(group.roles), 2)
         with self.subTest("policies inherited from roles are returned when lookup policies is called"):

--- a/tests/test_role_api.py
+++ b/tests/test_role_api.py
@@ -16,7 +16,6 @@ sys.path.insert(0, pkg_root)  # noqa
 from tests.base_api_test import BaseAPITest
 from tests.common import get_auth_header, service_accounts, create_test_statement
 from tests.data import TEST_NAMES_NEG, TEST_NAMES_POS
-from fusillade import Config
 from fusillade.clouddirectory import Role
 
 

--- a/tests/test_role_api.py
+++ b/tests/test_role_api.py
@@ -16,7 +16,7 @@ sys.path.insert(0, pkg_root)  # noqa
 from tests.base_api_test import BaseAPITest
 from tests.common import get_auth_header, service_accounts, create_test_statement
 from tests.data import TEST_NAMES_NEG, TEST_NAMES_POS
-from fusillade import directory, Config
+from fusillade import Config
 from fusillade.clouddirectory import Role
 
 
@@ -223,8 +223,8 @@ class TestRoleApi(BaseAPITest, unittest.TestCase):
             } for role_id, description in TEST_NAMES_NEG if role_id is not ''
         ])
         policy = create_test_statement("test_role")
-        Role.create(directory, role_id, policy)
-        [Role.create(directory, role_id, policy) for role_id, _ in TEST_NAMES_POS]
+        Role.create(role_id, policy)
+        [Role.create(role_id, policy) for role_id, _ in TEST_NAMES_POS]
         for test in tests:
             with self.subTest(test['name']):
                 url = furl('/v1/role/{}'.format(test['role_id']))
@@ -244,7 +244,7 @@ class TestRoleApi(BaseAPITest, unittest.TestCase):
         policy_1 = create_test_statement(role_id)
         policy_2 = create_test_statement('ABCD')
         policy_invalid = "invalid policy"
-        Role.create(directory, role_id, policy_1)
+        Role.create(role_id, policy_1)
         admin_auth_header = get_auth_header(service_accounts['admin'])
         tests = [
             {

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -29,14 +29,14 @@ class TestRole(unittest.TestCase):
     def test_role_default(self):
         with self.subTest("a role is set to default policy when role.create is called without a statement."):
             role_name = "test_role_default"
-            role = Role.create(self.directory, role_name)
+            role = Role.create(role_name)
             self.assertEqual(role.name, role_name)
             self.assertEqual(role.get_policy(), self.default_role_statement)
 
     def test_role_statement(self):
         role_name = "test_role_specified"
         statement = create_test_statement(role_name)
-        role = Role.create(self.directory, role_name, statement)
+        role = Role.create(role_name, statement)
         with self.subTest("a role is created with specified statement when role.create is called with a statement"):
             self.assertEqual(role.name, role_name)
 

--- a/tests/test_user_api.py
+++ b/tests/test_user_api.py
@@ -42,7 +42,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
                 'name': f'201 returned when creating a user with group only',
                 'json_request_body': {
                     "user_id": "test_post_user1@email.com",
-                    "groups": [Group.create(directory, "group_01").name]
+                    "groups": [Group.create( "group_01").name]
                 },
                 'response': {
                     'code': 201
@@ -52,7 +52,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
                 'name': f'201 returned when creating a user with role only',
                 'json_request_body': {
                     "user_id": "test_post_user2@email.com",
-                    "roles": [Role.create(directory, "role_02").name]
+                    "roles": [Role.create( "role_02").name]
                 },
                 'response': {
                     'code': 201
@@ -72,8 +72,8 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
                 'name': f'201 returned when creating a user with group, role and policy',
                 'json_request_body': {
                     "user_id": "test_post_user4@email.com",
-                    "groups": [Group.create(directory, "group_04").name],
-                    "roles": [Role.create(directory, "role_04").name],
+                    "groups": [Group.create( "group_04").name],
+                    "roles": [Role.create( "role_04").name],
                     "policy": create_test_statement("policy_04")
                 },
                 'response': {
@@ -83,8 +83,8 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
             {
                 'name': f'400 returned when creating a user without username',
                 'json_request_body': {
-                    "groups": [Group.create(directory, "group_05").name],
-                    "roles": [Role.create(directory, "role_05").name],
+                    "groups": [Group.create( "group_05").name],
+                    "roles": [Role.create( "role_05").name],
                     "policy": create_test_statement("policy_05")
                 },
                 'response': {
@@ -182,7 +182,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
                     'status': test['status']
                 }
                 url.add(query_params=query_params)
-                user = User.provision_user(directory, test['name'])
+                user = User.provision_user( test['name'])
                 if test['status'] == 'disabled':
                     user.enable()
                 resp = self.app.put(url.url, headers=headers)
@@ -194,7 +194,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
                 'name': "test_put_user_group0@email.com",
                 'action': 'add',
                 'json_request_body': {
-                    "groups": [Group.create(directory, "group_0").name]
+                    "groups": [Group.create( "group_0").name]
                 },
                 'response': {
                     'code': 200
@@ -204,7 +204,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
                 'name': "test_put_user_group1@email.com",
                 'action': 'remove',
                 'json_request_body': {
-                    "groups": [Group.create(directory, "group_1").name]
+                    "groups": [Group.create( "group_1").name]
                 },
                 'response': {
                     'code': 200
@@ -222,7 +222,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
                     'action': test['action']
                 }
                 url.add(query_params=query_params)
-                user = User.provision_user(directory, test['name'])
+                user = User.provision_user( test['name'])
                 if test['action'] == 'remove':
                     user.add_groups(test['json_request_body']['groups'])
                 resp = self.app.put(url.url, headers=headers, data=data)
@@ -233,10 +233,10 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
         headers.update(get_auth_header(service_accounts['admin']))
         name = "test_user_group_api@email.com"
         key = 'groups'
-        user = User.provision_user(directory, name)
+        user = User.provision_user( name)
         resp = self.app.get(f'/v1/user/{name}/groups', headers=headers)
         self.assertEqual(1, len(json.loads(resp.body)[key]))
-        groups = [Group.create(directory, f"group_{i}").name for i in range(10)]
+        groups = [Group.create( f"group_{i}").name for i in range(10)]
         user.add_groups(groups)
         self._test_paging(f'/v1/user/{name}/groups', headers, 6, key)
 
@@ -246,7 +246,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
                 'name': "test_put_user_role0@email.com",
                 'action': 'add',
                 'json_request_body': {
-                    "roles": [Role.create(directory, "role_0").name]
+                    "roles": [Role.create( "role_0").name]
                 },
                 'response': {
                     'code': 200
@@ -256,7 +256,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
                 'name': "test_put_user_role1@email.com",
                 'action': 'remove',
                 'json_request_body': {
-                    "roles": [Role.create(directory, "role_1").name]
+                    "roles": [Role.create( "role_1").name]
                 },
                 'response': {
                     'code': 200
@@ -274,7 +274,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
                     'action': test['action']
                 }
                 url.add(query_params=query_params)
-                user = User.provision_user(directory, test['name'])
+                user = User.provision_user( test['name'])
                 if test['action'] == 'remove':
                     user.add_roles(test['json_request_body']['roles'])
                 resp = self.app.put(url.url, headers=headers, data=data)
@@ -285,11 +285,11 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
         headers.update(get_auth_header(service_accounts['admin']))
         name = "test_user_role_api@email.com"
         key = 'roles'
-        user = User.provision_user(directory, name)
+        user = User.provision_user( name)
         resp = self.app.get(f'/v1/user/{name}/roles', headers=headers)
-        user_role_names = [Role(directory, None, role).name for role in user.roles]
+        user_role_names = [Role( None, role).name for role in user.roles]
         self.assertEqual(0, len(json.loads(resp.body)[key]))
-        roles = [Role.create(directory, f"role_{i}").name for i in range(11)]
+        roles = [Role.create( f"role_{i}").name for i in range(11)]
         user.add_roles(roles)
         self._test_paging(f'/v1/user/{name}/roles', headers, 6, key)
 
@@ -298,12 +298,12 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
         headers.update(get_auth_header(service_accounts['admin']))
         name = "test_user_role_api@email.com"
         key = 'roles'
-        user = User.provision_user(directory, name)
+        user = User.provision_user( name)
         url = furl(f"/v1/user/{name}/owns", query_params={'resource_type': 'role'}).url
         resp = self.app.get(url, headers=headers)
-        user_role_names = [Role(directory, None, role).name for role in user.roles]
+        user_role_names = [Role( None, role).name for role in user.roles]
         self.assertEqual(0, len(json.loads(resp.body)[key]))
-        roles = [Role.create(directory, f"role_{i}") for i in range(11)]
+        roles = [Role.create( f"role_{i}") for i in range(11)]
         user.add_roles([role.name for role in roles])
         [user.add_ownership(role) for role in roles]
         self._test_paging(url, headers, 6, key)

--- a/tests/test_user_api.py
+++ b/tests/test_user_api.py
@@ -16,7 +16,6 @@ sys.path.insert(0, pkg_root)  # noqa
 from tests.base_api_test import BaseAPITest
 from tests.common import get_auth_header, service_accounts, create_test_statement
 from tests.data import TEST_NAMES_POS, TEST_NAMES_NEG
-from fusillade import directory
 from fusillade.clouddirectory import User, Group, Role
 
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -31,35 +31,35 @@ class TestUser(unittest.TestCase):
 
     def test_user_statement(self):
         name = "user_statement@test.com"
-        User.provision_user(self.directory, name, statement=self.default_policy)
-        test_user = User(self.directory, name)
+        User.provision_user(name, statement=self.default_policy)
+        test_user = User(name)
         self.assertEqual(test_user.get_policy(), self.default_policy)
 
     def test_get_attributes(self):
         name = "test_get_attributes@test.com"
-        user = User.provision_user(self.directory, name)
+        user = User.provision_user(name)
         self.assertEqual(user.get_attributes(['name'])['name'], name)
 
     def test_get_user_policy(self):
         name = "test_get_user_policy@test.com"
-        user = User(self.directory, name)
+        user = User(name)
         with self.subTest("new user is automatically provisioned on demand with default settings when "
                           "lookup_policy is called for a new user."):
             self.assertEqual(sorted(user.lookup_policies()), self.default_user_policies)
         with self.subTest("error is returned when provision_user is called for an existing user"):
-            self.assertRaises(FusilladeHTTPException, user.provision_user, self.directory, name)
+            self.assertRaises(FusilladeHTTPException, user.provision_user, name)
         with self.subTest("an existing users info is retrieved when instantiating User class for an existing user"):
-            user = User(self.directory, name)
+            user = User(name)
             self.assertEqual(sorted(user.lookup_policies()), self.default_user_policies)
 
     def test_get_groups(self):
         name = "test_get_groups@test.com"
         test_groups = [(f"group_{i}", create_test_statement(f"GroupPolicy{i}")) for i in range(5)]
-        groups = [Group.create(self.directory, *i) for i in test_groups]
+        groups = [Group.create(*i) for i in test_groups]
 
-        user = User.provision_user(self.directory, name)
+        user = User.provision_user(name)
         with self.subTest("A user is in the public group when user is first created."):
-            self.assertEqual(Group(self.directory, object_ref=user.groups[0]).name, 'user_default')
+            self.assertEqual(Group(object_ref=user.groups[0]).name, 'user_default')
 
         user.add_groups([])
         with self.subTest("A user is added to no groups when add_groups is called with no groups"):
@@ -84,8 +84,8 @@ class TestUser(unittest.TestCase):
     def test_remove_groups(self):
         name = "test_remove_group@test.com"
         test_groups = [(f"group_{i}", create_test_statement(f"GroupPolicy{i}")) for i in range(5)]
-        groups = [Group.create(self.directory, *i).name for i in test_groups]
-        user = User.provision_user(self.directory, name)
+        groups = [Group.create(*i).name for i in test_groups]
+        user = User.provision_user(name)
         with self.subTest("A user is removed from a group when remove_group is called for a group the user belongs "
                           "to."):
             user.add_groups(groups)
@@ -104,7 +104,7 @@ class TestUser(unittest.TestCase):
 
     def test_set_policy(self):
         name = "test_set_policy@test.com"
-        user = User.provision_user(self.directory, name)
+        user = User.provision_user(name)
         with self.subTest("The initial user policy is None, when the user is first created"):
             self.assertFalse(user.get_policy())
 
@@ -127,7 +127,7 @@ class TestUser(unittest.TestCase):
 
     def test_status(self):
         name = "test_set_policy@test.com"
-        user = User.provision_user(self.directory, name)
+        user = User.provision_user(name)
 
         with self.subTest("A user's status is enabled when provisioned."):
             self.assertEqual(user.status, 'Enabled')
@@ -141,20 +141,20 @@ class TestUser(unittest.TestCase):
     def test_roles(self):
         name = "test_sete_policy@test.com"
         test_roles = [(f"Role_{i}", create_test_statement(f"RolePolicy{i}")) for i in range(5)]
-        roles = [Role.create(self.directory, *i).name for i in test_roles]
+        roles = [Role.create(*i).name for i in test_roles]
         role_names, role_statements = zip(*test_roles)
         role_names = sorted(role_names)
         role_statements = sorted(role_statements)
 
-        user = User.provision_user(self.directory, name)
-        user_role_names = [Role(self.directory, None, role).name for role in user.roles]
+        user = User.provision_user(name)
+        user_role_names = [Role(None, role).name for role in user.roles]
         with self.subTest("a user has the default_user roles when created."):
             self.assertEqual(user_role_names, [])
 
         role_name, role_statement = test_roles[0]
         with self.subTest("A user has one role when a role is added."):
             user.add_roles([role_name])
-            user_role_names = [Role(self.directory, None, role).name for role in user.roles]
+            user_role_names = [Role(None, role).name for role in user.roles]
             self.assertEqual(user_role_names, [role_name])
 
         with self.subTest("An error is raised when adding a role a user already has."):
@@ -178,7 +178,7 @@ class TestUser(unittest.TestCase):
 
         with self.subTest("A user has multiple roles when multiple roles are added to user."):
             user.add_roles(role_names)
-            user_role_names = [Role(self.directory, None, role).name for role in user.roles]
+            user_role_names = [Role(None, role).name for role in user.roles]
             self.assertEqual(sorted(user_role_names), sorted(role_names))
 
         with self.subTest("A user inherits multiple role policies when the user has multiple roles."):
@@ -186,7 +186,7 @@ class TestUser(unittest.TestCase):
                                  sorted([user.get_policy(), *self.default_user_policies, *role_statements]))
 
         with self.subTest("A user's roles are listed when a listing a users roles."):
-            user_role_names = [Role(self.directory, None, role).name for role in user.roles]
+            user_role_names = [Role(None, role).name for role in user.roles]
             self.assertListEqual(sorted(user_role_names), sorted(role_names))
 
         with self.subTest("Multiple roles are removed from a user when a multiple roles are specified for removal."):
@@ -198,14 +198,14 @@ class TestUser(unittest.TestCase):
         A user inherits policies from groups and roles when the user is apart of a group and assigned a role.
         """
         name = "test_set_policy@test.com"
-        user = User.provision_user(self.directory, name)
+        user = User.provision_user(name)
         test_groups = [(f"group_{i}", create_test_statement(f"GroupPolicy{i}")) for i in range(5)]
-        [Group.create(self.directory, *i) for i in test_groups]
+        [Group.create(*i) for i in test_groups]
         group_names, group_statements = zip(*test_groups)
         group_names = sorted(group_names)
         group_statements = sorted(group_statements)
         test_roles = [(f"role_{i}", create_test_statement(f"RolePolicy{i}")) for i in range(5)]
-        [Role.create(self.directory, *i) for i in test_roles]
+        [Role.create(*i) for i in test_roles]
         role_names, role_statements = zip(*test_roles)
         role_names = sorted(role_names)
         role_statements = sorted(role_statements)
@@ -213,8 +213,8 @@ class TestUser(unittest.TestCase):
         user.add_roles(role_names)
         user.add_groups(group_names)
         user.set_policy(self.default_policy)
-        user_role_names = [Role(self.directory, object_ref=role).name for role in user.roles]
-        user_group_names = [Group(self.directory, object_ref=group).name for group in user.groups]
+        user_role_names = [Role(object_ref=role).name for role in user.roles]
+        user_group_names = [Group(object_ref=group).name for group in user.groups]
 
         self.assertListEqual(sorted(user_role_names), role_names)
         self.assertEqual(sorted(user_group_names), group_names + ['user_default'])
@@ -223,14 +223,14 @@ class TestUser(unittest.TestCase):
                                  )
 
     def test_ownership(self):
-        user = User.provision_user(self.directory, 'test_user')
-        group = Group.create(self.directory, "group_ownership")
+        user = User.provision_user('test_user')
+        group = Group.create("group_ownership")
         with self.subTest("A user is not an owner when new group is created"):
             self.assertFalse(user.is_owner(group))
         user.add_ownership(group)
         with self.subTest("A user is owner after assigning ownership."):
             self.assertTrue(user.is_owner(group))
-        group2 = Group.create(self.directory, "group_ownership2")
+        group2 = Group.create("group_ownership2")
         user.add_ownership(group2)
         with self.subTest("List groups owned, when list_owned is called"):
             resp = user.list_owned(Group)
@@ -240,7 +240,7 @@ class TestUser(unittest.TestCase):
     @unittest.skip("TODO: unfinished and low priority")
     def test_remove_user(self):
         name = "test_get_user_policy@test.com"
-        user = User.provision_user(self.directory, name)
+        user = User.provision_user(name)
         self.assertEqual(len(self.directory.lookup_policy(user.reference)), 1)
         user.remove_user()
         self.directory.lookup_policy(user.reference)


### PR DESCRIPTION
Moved directory creation out of fusillade/__init__.py. The directory is created during deployment this gives use better control of when the directory is created for testing. This also simplifies the code for CloudNode.