### PR TITLE
Adding groups and roles to policy evaluate

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -141,6 +141,21 @@ service configuration.
 * [Documentation (Read the Docs)](https://fusillade.readthedocs.io/)
 * [Package distribution (PyPI)](https://pypi.python.org/pypi/fusillade)
 
+# Policies
+
+
+## Special Fusillade Context Keys
+
+In the same way AWS iam provides [context keys available to all services](https://docs.aws.amazon
+.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-globally-available), fusillade provides 
+context keys that can be used in your policies.
+
+- `fus:groups` - is a list of groups the current user belongs. This can be used to restrict permission based on 
+  the group association
+- `fus:roles` - is a list of roles the current user belongs. This can be used to restrict permission based on 
+  the role association
+- `fus:user_email` - is the email of the user. This can be used to restrict permission based on the users email.
+
 ### Bugs
 Please report bugs, issues, feature requests, etc. on [GitHub](https://github.com/HumanCellAtlas/fusillade/issues).
 

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -11,7 +11,7 @@ import itertools
 import json
 import logging
 import os
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 from datetime import datetime
 from enum import Enum, auto
 from json import JSONDecodeError
@@ -823,7 +823,7 @@ class CloudDirectory:
             ConsistencyLevel='EVENTUAL'
         )
 
-    def get_policies(self, policy_paths: List[Dict[str, Any]], policy_type='IAMPolicy') -> List[str]:
+    def get_policies(self, policy_paths: List[Dict[str, Any]], policy_type='IAMPolicy') -> Dict[str, List[str]]:
         # Parse the policyIds from the policies path. Only keep the unique ids
         policy_ids = set(
             [
@@ -836,26 +836,47 @@ class CloudDirectory:
 
         # retrieve the policies in a single request
         operations = [
-            {
-                'GetObjectAttributes': {
-                    'ObjectReference': {'Selector': f'${policy_id}'},
-                    'SchemaFacet': {
-                        'SchemaArn': self.node_schema,
-                        'FacetName': 'POLICY'
-                    },
-                    'AttributeNames': ['policy_document']
-                }
-            }
-            for policy_id in policy_ids
-        ]
+                         {
+                             'GetObjectAttributes': {
+                                 'ObjectReference': {'Selector': f'${policy_id}'},
+                                 'SchemaFacet': {
+                                     'SchemaArn': self.node_schema,
+                                     'FacetName': 'POLICY'
+                                 },
+                                 'AttributeNames': ['policy_document']
+                             }
+                         }
+                         for policy_id in policy_ids
+                     ] + [
+                         {
+                             'GetObjectAttributes': {
+                                 'ObjectReference': {'Selector': f'${policy_id}'},
+                                 'SchemaFacet': {
+                                     'SchemaArn': self._schema,
+                                     'FacetName': 'IAMPolicy'
+                                 },
+                                 'AttributeNames': ['name', 'type']
+                             }
+                         }
+                         for policy_id in policy_ids
+                     ]
 
         # parse the policies from the responses
-        policies = [
+        responses = cd_client.batch_read(DirectoryArn=self._dir_arn, Operations=operations)['Responses']
+        middle = len(responses) // 2
+        results = defaultdict(list)
+        results['policies'].extend([
             response['SuccessfulResponse']['GetObjectAttributes']['Attributes'][0]['Value']['BinaryValue'].decode(
                 'utf-8')
-            for response in cd_client.batch_read(DirectoryArn=self._dir_arn, Operations=operations)['Responses']
-        ]
-        return policies
+            for response in responses[:middle]]
+        )
+        for response in responses[middle:]:
+            try:
+                _type, name = response['SuccessfulResponse']['GetObjectAttributes']['Attributes']
+            except KeyError:
+                continue
+            results[_type['Value']['StringValue']].append(name['Value']['StringValue'])
+        return results
 
     def get_object_information(self, obj_ref: str) -> Dict[str, Any]:
         """
@@ -1127,7 +1148,7 @@ class PolicyMixin:
 
     def lookup_policies(self) -> List[str]:
         policy_paths = self.cd.lookup_policy(self.object_ref)
-        return self.cd.get_policies(policy_paths)
+        return self.cd.get_policies(policy_paths)['policies']  # TODO use roles and groups extraced from policy
 
     def create_policy(self, statement: str, policy_type='IAMPolicy', **kwargs) -> str:
         """
@@ -1247,7 +1268,7 @@ class PolicyMixin:
                                                 params,
                                                 self.cd.node_schema)
             except cd_client.exceptions.ResourceNotFoundException:
-                self.create_policy(statement, policy_type)
+                self.create_policy(statement, policy_type, type=self.object_type, name=self.name)
         except cd_client.exceptions.LimitExceededException as ex:
             raise FusilladeHTTPException(ex)
         else:
@@ -1444,7 +1465,7 @@ class User(CloudNode, RolesMixin, PolicyMixin, OwnershipMixin):
             policy_paths = self.lookup_policies_batched()
         else:
             raise AuthorizationException(f"User {self.status}")
-        return self.cd.get_policies(policy_paths)
+        return self.cd.get_policies(policy_paths)['policies']  # TODO use roles and groups extraced from policy
 
     def lookup_policies_batched(self):
         object_refs = self.groups + [self.object_ref]

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -1149,7 +1149,7 @@ class PolicyMixin:
 
     def get_authz_params(self) -> List[str]:
         policy_paths = self.cd.lookup_policy(self.object_ref)
-        return self.cd.get_policies(policy_paths)['policies']  # TODO use roles and groups extraced from policy
+        return self.cd.get_policies(policy_paths)
 
     def create_policy(self, statement: str, policy_type='IAMPolicy', **kwargs) -> str:
         """

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -1147,9 +1147,9 @@ class PolicyMixin:
     """Adds policy support to a cloudNode"""
     allowed_policy_types = ['IAMPolicy']
 
-    def lookup_policies(self) -> List[str]:
+    def get_authz_params(self) -> List[str]:
         policy_paths = self.cd.lookup_policy(self.object_ref)
-        return self.cd.get_policies(policy_paths)['policies']  # TODO use roles and groups extraced from policy
+        return self.cd.get_policies(policy_paths)
 
     def create_policy(self, statement: str, policy_type='IAMPolicy', **kwargs) -> str:
         """
@@ -1461,12 +1461,12 @@ class User(CloudNode, RolesMixin, PolicyMixin, OwnershipMixin):
         self._groups: Optional[List[str]] = None
         self._roles: Optional[List[str]] = None
 
-    def lookup_policies(self) -> List[str]:
+    def get_authz_params(self) -> Dict[str, List[str]]:
         if self.is_enabled():
             policy_paths = self.lookup_policies_batched()
         else:
             raise AuthorizationException(f"User {self.status}")
-        return self.cd.get_policies(policy_paths)['policies']  # TODO use roles and groups extraced from policy
+        return self.cd.get_policies(policy_paths)
 
     def lookup_policies_batched(self):
         object_refs = self.groups + [self.object_ref]

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -1466,7 +1466,7 @@ class User(CloudNode, RolesMixin, PolicyMixin, OwnershipMixin):
             policy_paths = self.lookup_policies_batched()
         else:
             raise AuthorizationException(f"User {self.status}")
-        return self.cd.get_policies(policy_paths)['policies']  # TODO use roles and groups extraced from policy
+        return self.cd.get_policies(policy_paths)
 
     def lookup_policies_batched(self):
         object_refs = self.groups + [self.object_ref]

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -873,10 +873,16 @@ class CloudDirectory:
         )
         for response in responses[middle:]:
             try:
-                _type, name = response['SuccessfulResponse']['GetObjectAttributes']['Attributes']
+                attrs = response['SuccessfulResponse']['GetObjectAttributes']['Attributes']
+                if attrs[0]['Key']['Name'] == 'name':
+                    name = attrs[0]['Value']['StringValue']
+                    _type = attrs[1]['Value']['StringValue']
+                else:
+                    name = attrs[1]['Value']['StringValue']
+                    _type = attrs[0]['Value']['StringValue']
             except KeyError:
                 continue
-            results[_type['Value']['StringValue']].append(name['Value']['StringValue'])
+            results[_type].append(name)
         return results
 
     def get_object_information(self, obj_ref: str) -> Dict[str, Any]:

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -1153,7 +1153,7 @@ class PolicyMixin:
     """Adds policy support to a cloudNode"""
     allowed_policy_types = ['IAMPolicy']
 
-    def get_authz_params(self) -> List[str]:
+    def get_authz_params(self) -> Dict[str, List[str]]:
         policy_paths = self.cd.lookup_policy(self.object_ref)
         return self.cd.get_policies(policy_paths)
 

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -836,30 +836,31 @@ class CloudDirectory:
 
         # retrieve the policies in a single request
         operations = [
-                         {
-                             'GetObjectAttributes': {
-                                 'ObjectReference': {'Selector': f'${policy_id}'},
-                                 'SchemaFacet': {
-                                     'SchemaArn': self.node_schema,
-                                     'FacetName': 'POLICY'
-                                 },
-                                 'AttributeNames': ['policy_document']
-                             }
-                         }
-                         for policy_id in policy_ids
-                     ] + [
-                         {
-                             'GetObjectAttributes': {
-                                 'ObjectReference': {'Selector': f'${policy_id}'},
-                                 'SchemaFacet': {
-                                     'SchemaArn': self._schema,
-                                     'FacetName': 'IAMPolicy'
-                                 },
-                                 'AttributeNames': ['name', 'type']
-                             }
-                         }
-                         for policy_id in policy_ids
-                     ]
+            {
+                'GetObjectAttributes': {
+                    'ObjectReference': {'Selector': f'${policy_id}'},
+                    'SchemaFacet': {
+                        'SchemaArn': self.node_schema,
+                        'FacetName': 'POLICY'
+                    },
+                    'AttributeNames': ['policy_document']
+                }
+            }
+            for policy_id in policy_ids
+        ]
+        operations.extend([
+            {
+                'GetObjectAttributes': {
+                    'ObjectReference': {'Selector': f'${policy_id}'},
+                    'SchemaFacet': {
+                        'SchemaArn': self._schema,
+                        'FacetName': 'IAMPolicy'
+                    },
+                    'AttributeNames': ['name', 'type']
+                }
+            }
+            for policy_id in policy_ids
+        ])
 
         # parse the policies from the responses
         responses = cd_client.batch_read(DirectoryArn=self._dir_arn, Operations=operations)['Responses']

--- a/fusillade/directory_schema.json
+++ b/fusillade/directory_schema.json
@@ -92,7 +92,24 @@
       "objectType": "LEAF_NODE"
     },
     "IAMPolicy": {
-      "facetAttributes": {},
+      "facetAttributes": {
+        "type": {
+          "attributeDefinition": {
+            "attributeType": "STRING",
+            "isImmutable": true,
+            "attributeRules": {}
+          },
+          "requiredBehavior": "NOT_REQUIRED"
+        },
+        "name": {
+          "attributeDefinition": {
+            "attributeType": "STRING",
+            "isImmutable": true,
+            "attributeRules": {}
+          },
+          "requiredBehavior": "NOT_REQUIRED"
+        }
+      },
       "objectType": "POLICY"
     }
   },

--- a/fusillade/utils/authorize.py
+++ b/fusillade/utils/authorize.py
@@ -1,7 +1,7 @@
 import functools
 import json
 import logging
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Optional, Union
 
 from dcplib.aws import clients as aws_clients
 
@@ -17,9 +17,10 @@ def evaluate_policy(
         actions: List[str],
         resources: List[str],
         policies: List[str],
-        context_entries: List[Dict] = []
+        context_entries: List[Dict] = None
 ) -> bool:
     logger.debug(dict(policies=policies))
+    context_entries = context_entries if context_entries else []
     response = iam.simulate_custom_policy(
         PolicyInputList=policies,
         ActionNames=actions,
@@ -54,24 +55,32 @@ def assert_authorized(user, actions, resources, context_entries=None):
     """
     u = User(user)
     try:
-        policies = u.lookup_policies()
+        authz_params = u.get_authz_params()
     except AuthorizationException:
         raise FusilladeForbiddenException(detail="User must be enabled to make authenticated requests.")
-    _context_entries = [
-        {
-            'ContextKeyName': key,
-            'ContextKeyValues': value if isinstance(value, list) else [value],
-            'ContextKeyType': 'string'
-        } for key, value in context_entries.items()] if context_entries else []
-    if not evaluate_policy(user, actions, resources, policies, _context_entries):
-        logger.info(dict(message="User not authorized.", user=u._path_name, action=actions, resources=resources))
-        raise FusilladeForbiddenException()
     else:
-        logger.info(dict(message="User authorized.", user=u._path_name, action=actions,
-                         resources=resources))
+        context_entries.append(restricted_context_entries(authz_params))
+        if not evaluate_policy(user, actions, resources, authz_params['policies'], context_entries):
+            logger.info(dict(message="User not authorized.", user=u._path_name, action=actions, resources=resources))
+            raise FusilladeForbiddenException()
+        else:
+            logger.info(dict(message="User authorized.", user=u._path_name, action=actions,
+                             resources=resources))
 
 
-def format_resources(resources: List[str], resource_param: List[str], kwargs: Dict[str, Any]):
+restricted_set = {'fus:groups', 'fus:roles', 'fus:user_email'}
+
+
+def restricted_context_entries(authz_params):
+    """
+
+    :param authz_params:
+    :return:
+    """
+    return format_context_entries({'fus:groups': 'group', 'fus:roles': 'role'}, authz_params)
+
+
+def format_resources(resources: List[str], resource_param: List[str], kwargs: Dict[str, Union[List[str], str]]):
     """
     >>> resources=['hello/{user_name}']
     >>> resource_param=['user_name']
@@ -92,37 +101,60 @@ def format_resources(resources: List[str], resource_param: List[str], kwargs: Di
     return [resource.format_map(_rp) for resource in resources]
 
 
-def format_context_entries(context_entries, kwargs):
+context_type_mapping = {
+    str: 'string',
+    # int: 'numeric',  # TODO: add support
+    # float: 'numeric',  # TODO: add support
+    # bool: 'bool'  # TODO: add support
+}
+
+
+def format_context_entries(context_entries: Dict[str, str],
+                           kwargs: Dict[str, Union[List[str], str]],
+                           restricted: List[str] = None) -> List[Dict]:
     """
-    >>> context_entries={"fus:context": "user_name"}
-    >>> kwargs={'user_name': "bob"}
+    >>> context_entries={"fus:context": "user_name", "fus:groups": "group"}
+    >>> kwargs={'user_name': "bob", 'group': ['g1', 'g2']}
     >>> x = format_resources(context_entries, kwargs)
-    >>> x == {"fus:context": "bob"}
+    >>> x == [{"ContextKeyName": "fus:context","ContextKeyValues":["bob"],"ContextKeyType": "string"},
+    >>>       {"ContextKeyName": "fus:groups","ContextKeyValues":["g1", "g2"],"ContextKeyType": "stringList"}]
 
     :param context_entries:
     :param kwargs:
+    :param restricted: A list of context variables not allowed.
     :return:
     """
-    _ce = dict()
+    _ce = []
+    restricted = restricted if restricted else []
     for key, value in context_entries.items():
-        if isinstance(value, list):
-            temp = []
-            for i in value:
-                v = kwargs.get(i)
-                if isinstance(v, str):
-                    temp.append(v)
-            _ce[key] = temp
+        if key in restricted:
+            continue
         else:
             v = kwargs.get(value)
-            if isinstance(v, str):
-                _ce[key] = v
+            if v is None:
+                continue
+            elif isinstance(v, list):
+                v_type = type(v[0])
+                if all(isinstance(i, v_type) for i in v):
+                    _ce.append({
+                        'ContextKeyName': key,
+                        'ContextKeyValues': v,
+                        'ContextKeyType': f"{context_type_mapping[v_type]}List"
+                    })
+            else:
+                v_type = type(v[0])
+                _ce.append({
+                    'ContextKeyName': key,
+                    'ContextKeyValues': [v],
+                    'ContextKeyType': context_type_mapping[v_type]
+                })
     return _ce
 
 
 def authorize(actions: List[str],
               resources: List[str],
               resource_params: Optional[List[str]] = None,
-              context_entries: Optional[List[str]] = None
+              context_entries: Optional[Dict[str, str]] = None
               ):
     """
     A decorator for assert_authorized
@@ -130,6 +162,7 @@ def authorize(actions: List[str],
     :param actions: The actions passed to assert_authorized
     :param resources: The resources passed to assert_authorized
     :param resource_params: Keys to extract from kwargs and map into the resource strings.
+    :param context_entries: Keys to extract from kwargs and map into iam policy context variables
     :return:
     """
 
@@ -139,7 +172,8 @@ def authorize(actions: List[str],
             assert_authorized(kwargs['token_info']['https://auth.data.humancellatlas.org/email'],
                               actions,
                               format_resources(resources, resource_params, kwargs) if resource_params else resources,
-                              format_context_entries(context_entries, kwargs) if context_entries else None
+                              format_context_entries(context_entries, kwargs,
+                                                     restricted_set) if context_entries else None
                               )
             return func(*args, **kwargs)
 

--- a/fusillade/utils/authorize.py
+++ b/fusillade/utils/authorize.py
@@ -54,12 +54,13 @@ def assert_authorized(user, actions, resources, context_entries=None):
     :return:
     """
     u = User(user)
+    context_entries = context_entries if context_entries else []
     try:
         authz_params = u.get_authz_params()
     except AuthorizationException:
         raise FusilladeForbiddenException(detail="User must be enabled to make authenticated requests.")
     else:
-        context_entries.append(restricted_context_entries(authz_params))
+        context_entries.extend(restricted_context_entries(authz_params))
         if not evaluate_policy(user, actions, resources, authz_params['policies'], context_entries):
             logger.info(dict(message="User not authorized.", user=u._path_name, action=actions, resources=resources))
             raise FusilladeForbiddenException()

--- a/fusillade/utils/authorize.py
+++ b/fusillade/utils/authorize.py
@@ -132,7 +132,7 @@ def format_context_entries(context_entries: Dict[str, str],
     _ce = []
     restricted = restricted if restricted else []
     for key, value in context_entries.items():
-        if not key in restricted:
+        if key not in restricted:
             v = kwargs.get(value)
             if v is None:
                 continue

--- a/fusillade/utils/authorize.py
+++ b/fusillade/utils/authorize.py
@@ -142,10 +142,11 @@ def format_context_entries(context_entries: Dict[str, str],
                     suffix = "List"
             else:
                 v_type = type(v)
+                v = [v]
                 suffix = ""
             _ce.append({
                 'ContextKeyName': key,
-                'ContextKeyValues': [v],
+                'ContextKeyValues': v,
                 'ContextKeyType': f"{context_type_mapping[v_type]}{suffix}"
             })
     return _ce

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -48,7 +48,7 @@ class TestGroup(unittest.TestCase):
     def test_policy(self):
         group = Group.create("new_group")
         with self.subTest("Only one policy is attached when lookup policy is called on a group without any roles"):
-            policies = group.lookup_policies()
+            policies = group.get_authz_params()['policies']
             self.assertEqual(len(policies), 1)
             self.assertEqual(policies[0], group._set_policy_id(self.default_group_statement, group.name))
 
@@ -56,7 +56,7 @@ class TestGroup(unittest.TestCase):
         statement = create_test_statement(group_name)
         with self.subTest("The group policy changes when satement is set"):
             group.set_policy(statement)
-            policies = group.lookup_policies()
+            policies = group.get_authz_params()['policies']
             self.assertEqual(policies[0], group._set_policy_id(statement, group.name))
 
         with self.subTest("error raised when invalid statement assigned to group.get_policy()."):
@@ -107,7 +107,7 @@ class TestGroup(unittest.TestCase):
             group.add_roles(roles)
             self.assertEqual(len(group.roles), 2)
         with self.subTest("policies inherited from roles are returned when lookup policies is called"):
-            group_policies = sorted(group.lookup_policies())
+            group_policies = sorted(group.get_authz_params()['policies'])
             role_policies = sorted([role.get_policy() for role in role_objs] + [group._set_policy_id(
                 self.default_group_statement, group.name)])
             self.assertListEqual(group_policies, role_policies)


### PR DESCRIPTION
- renamed lookup_policies to get_authz_params
- building context data structure in format_context_entries for reusability
- update docstring for format_context_entries
- supporting context_entries that are lists and lists of strings
- format_context_entries can now ignore a list of entries. This prevent abuse of context entries.
- added context key to readme