### PR TITLE
Configurable ConsistancyLevel for Cloud Directory operation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ $(tests): %.py : lint
 	coverage run -p --source=fusillade $*.py -v
 
 unittest: before-test
-	python -m unittest discover -p test_*.py -t .
+	python -m unittest discover -p test_*.py -t . -v
 
 integration_test:
 	source environment && $(MAKE) FUS_TEST_MODE=integration unittest

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ $(tests): %.py : lint
 	coverage run -p --source=fusillade $*.py -v
 
 unittest: before-test
-	python -m unittest discover -p test_*.py -t . -v
+	python -m unittest discover -p test_*api.py -t . -v
 
 integration_test:
 	source environment && $(MAKE) FUS_TEST_MODE=integration unittest

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -629,9 +629,10 @@ class CloudDirectory:
             [self.batch_detach_object(parent_ref, link_name) for parent_ref, link_name in self.list_object_parents(
                 policy_ref,
                 ConsistencyLevel=ConsistencyLevel.SERIALIZABLE.name)])
-        cd_client.delete_object(DirectoryArn=self._dir_arn, ObjectReference={'Selector': policy_ref})
+        retry(**cd_read_retry_parameters)(cd_client.delete_object)(
+            DirectoryArn=self._dir_arn,
+            ObjectReference={'Selector': policy_ref})
 
-    @retry(**cd_write_retry_parameters)
     def delete_object(self, obj_ref: str) -> None:
         """
         See details on deletion requirements for more info
@@ -649,7 +650,9 @@ class CloudDirectory:
         self.batch_write([self.batch_detach_typed_link(i) for i in self.list_outgoing_typed_links(
             obj_ref,
             ConsistencyLevel=ConsistencyLevel.SERIALIZABLE.name)])
-        cd_client.delete_object(DirectoryArn=self._dir_arn, ObjectReference={'Selector': obj_ref})
+        retry(**cd_read_retry_parameters)(cd_client.delete_object)(
+            DirectoryArn=self._dir_arn,
+            ObjectReference={'Selector': obj_ref})
 
     @staticmethod
     def batch_detach_policy(policy_ref: str, object_ref: str):

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -644,8 +644,8 @@ class CloudDirectory:
         """
         [self.delete_policy(policy_ref) for policy_ref in self.list_object_policies(
             obj_ref, ConsistencyLevel=ConsistencyLevel.SERIALIZABLE.name)]
-        self.batch_write([self.batch_detach_object(parent_ref, link_name)
-                          for parent_ref, link_name in self.list_object_parents(
+        self.batch_write(
+            [self.batch_detach_object(parent_ref, link_name) for parent_ref, link_name in self.list_object_parents(
                 obj_ref, ConsistencyLevel=ConsistencyLevel.SERIALIZABLE.name)])
         self.batch_write([self.batch_detach_typed_link(i) for i in self.list_incoming_typed_links(
             object_ref=obj_ref,

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -319,6 +319,7 @@ class CloudDirectory:
                             **kwargs
                             )
 
+    @retry(**cd_read_retry_parameters)
     def _list_typed_links(self,
                           func: Callable,
                           key: str,
@@ -349,7 +350,7 @@ class CloudDirectory:
         else:
             return _paging_loop(func, key, **kwargs)
 
-    @retry(**cd_read_retry_parameters)
+
     def list_outgoing_typed_links(self,
                                   object_ref: str,
                                   filter_attribute_ranges: List = None,
@@ -367,7 +368,6 @@ class CloudDirectory:
                                       filter_typed_link,
                                       **kwargs)
 
-    @retry(**cd_read_retry_parameters)
     def list_incoming_typed_links(
             self,
             object_ref: str,

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -40,15 +40,13 @@ default_admin_role_path = os.path.join(proj_path, '..', 'policies', 'default_adm
 default_user_role_path = os.path.join(proj_path, '..', 'policies', 'default_user_role.json')
 default_role_path = os.path.join(proj_path, '..', 'policies', 'default_role.json')
 
-cd_read_retry_parameters = dict(timeout=2,
+cd_read_retry_parameters = dict(timeout=5,
                                 delay=0.1,
-                                retryable=lambda e: isinstance(e, cd_client.exceptions.RetryableConflictException),
-                                logger=logger)
+                                retryable=lambda e: isinstance(e, cd_client.exceptions.RetryableConflictException))
 
 cd_write_retry_parameters = dict(timeout=5,
                                  delay=0.2,
-                                 retryable=lambda e: isinstance(e, cd_client.exceptions.RetryableConflictException),
-                                 logger=logger)
+                                 retryable=lambda e: isinstance(e, cd_client.exceptions.RetryableConflictException))
 
 
 def get_json_file(file_name):
@@ -240,6 +238,7 @@ class CloudDirectory:
         result = cd_client.list_object_children(**kwargs)
         return result['Children'], result.get("NextToken")
 
+    @retry(**cd_read_retry_parameters)
     def list_object_children(self, object_ref: str, **kwargs) -> Iterator[Tuple[str, str]]:
         """
         a wrapper around CloudDirectory.Client.list_object_children

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -629,9 +629,12 @@ class CloudDirectory:
             [self.batch_detach_object(parent_ref, link_name) for parent_ref, link_name in self.list_object_parents(
                 policy_ref,
                 ConsistencyLevel=ConsistencyLevel.SERIALIZABLE.name)])
-        retry(**cd_read_retry_parameters)(cd_client.delete_object)(
-            DirectoryArn=self._dir_arn,
-            ObjectReference={'Selector': policy_ref})
+        try:
+            retry(**cd_read_retry_parameters)(cd_client.delete_object)(
+                DirectoryArn=self._dir_arn,
+                ObjectReference={'Selector': policy_ref})
+        except cd_client.exceptions.ResourceNotFoundException:
+            pass
 
     def delete_object(self, obj_ref: str) -> None:
         """
@@ -650,9 +653,12 @@ class CloudDirectory:
         self.batch_write([self.batch_detach_typed_link(i) for i in self.list_outgoing_typed_links(
             obj_ref,
             ConsistencyLevel=ConsistencyLevel.SERIALIZABLE.name)])
-        retry(**cd_read_retry_parameters)(cd_client.delete_object)(
-            DirectoryArn=self._dir_arn,
-            ObjectReference={'Selector': obj_ref})
+        try:
+            retry(**cd_read_retry_parameters)(cd_client.delete_object)(
+                DirectoryArn=self._dir_arn,
+                ObjectReference={'Selector': obj_ref})
+        except cd_client.exceptions.ResourceNotFoundException:
+            pass
 
     @staticmethod
     def batch_detach_policy(policy_ref: str, object_ref: str):

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -178,13 +178,15 @@ class UpdateObjectParams(namedtuple("UpdateObjectParams", ['facet', 'attribute',
     pass
 
 
-cd_read_retry_parameters = dict(timeout=1,
+cd_read_retry_parameters = dict(timeout=2,
                                 delay=0.1,
-                                retryable=lambda e: isinstance(e, cd_client.exceptions.RetryableConflictException))
+                                retryable=lambda e: isinstance(e, cd_client.exceptions.RetryableConflictException),
+                                logger=logger)
 
 cd_write_retry_parameters = dict(timeout=5,
                                  delay=0.2,
-                                 retryable=lambda e: isinstance(e, cd_client.exceptions.RetryableConflictException))
+                                 retryable=lambda e: isinstance(e, cd_client.exceptions.RetryableConflictException),
+                                 logger=logger)
 
 
 class CloudDirectory:
@@ -349,7 +351,6 @@ class CloudDirectory:
             return [i for i in resp[key]], resp.get("NextToken")
         else:
             return _paging_loop(func, key, **kwargs)
-
 
     def list_outgoing_typed_links(self,
                                   object_ref: str,

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -146,7 +146,7 @@ def create_directory(name: str, schema: str, admins: List[str]) -> 'CloudDirecto
         return directory
 
 
-@retry(**cd_read_retry_parameters, inherit=True)
+@retry(**cd_read_retry_parameters)
 def _paging_loop(fn: Callable, key: str, upack_response: Optional[Callable] = None, **kwarg):
     while True:
         resp = fn(**kwarg)
@@ -629,12 +629,9 @@ class CloudDirectory:
             [self.batch_detach_object(parent_ref, link_name) for parent_ref, link_name in self.list_object_parents(
                 policy_ref,
                 ConsistencyLevel=ConsistencyLevel.SERIALIZABLE.name)])
-        try:
-            retry(**cd_read_retry_parameters)(cd_client.delete_object)(
-                DirectoryArn=self._dir_arn,
-                ObjectReference={'Selector': policy_ref})
-        except cd_client.exceptions.ResourceNotFoundException:
-            pass
+        retry(**cd_read_retry_parameters)(cd_client.delete_object)(
+            DirectoryArn=self._dir_arn,
+            ObjectReference={'Selector': policy_ref})
 
     def delete_object(self, obj_ref: str) -> None:
         """
@@ -653,12 +650,9 @@ class CloudDirectory:
         self.batch_write([self.batch_detach_typed_link(i) for i in self.list_outgoing_typed_links(
             obj_ref,
             ConsistencyLevel=ConsistencyLevel.SERIALIZABLE.name)])
-        try:
-            retry(**cd_read_retry_parameters)(cd_client.delete_object)(
-                DirectoryArn=self._dir_arn,
-                ObjectReference={'Selector': obj_ref})
-        except cd_client.exceptions.ResourceNotFoundException:
-            pass
+        retry(**cd_read_retry_parameters)(cd_client.delete_object)(
+            DirectoryArn=self._dir_arn,
+            ObjectReference={'Selector': obj_ref})
 
     @staticmethod
     def batch_detach_policy(policy_ref: str, object_ref: str):
@@ -805,7 +799,7 @@ class CloudDirectory:
             }
         }
 
-    @retry(**cd_write_retry_parameters, inherit=True)
+    @retry(**cd_write_retry_parameters)
     def batch_write(self, operations: list) -> List[dict]:
         """
         A wrapper around CloudDirectory.Client.batch_write
@@ -834,7 +828,7 @@ class CloudDirectory:
 
         return responses
 
-    @retry(**cd_read_retry_parameters, inherit=True)
+    @retry(**cd_read_retry_parameters)
     def batch_read(self, operations: List[Dict[str, Any]], **kwargs) -> Dict[str, Any]:
         """
         A wrapper around CloudDirectory.Client.batch_read

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -426,7 +426,7 @@ class CloudDirectory:
                                                    'FacetName': facet
                                                },
                                                AttributeNames=attributes,
-                                               ConsistencyLevel=ConsistencyLevel.SERIALIZABLE
+                                               ConsistencyLevel=ConsistencyLevel.SERIALIZABLE.name
                                                )
 
     def get_object_attribute_list(self, facet="LeafFacet", **kwargs) -> List[Dict[str, Any]]:

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -1037,8 +1037,7 @@ class CloudNode:
         ]
         if paged:
             result, next_token = get_links(self.object_ref, filter_attribute_ranges, facet,
-                                           next_token=next_token, paged=paged, per_page=per_page,
-                                           ConsistencyLevel=ConsistencyLevel.SERIALIZABLE.name)
+                                           next_token=next_token, paged=paged, per_page=per_page)
             if result:
                 operations = [self.cd.batch_get_attributes(
                     obj_ref[object_selection]['Selector'],
@@ -1057,8 +1056,7 @@ class CloudNode:
             return [
                 type_link[object_selection]['Selector']
                 for type_link in
-                get_links(self.object_ref, filter_attribute_ranges, facet,
-                          ConsistencyLevel=ConsistencyLevel.SERIALIZABLE.name)
+                get_links(self.object_ref, filter_attribute_ranges, facet)
             ]
 
     def _add_links_batch(self, links: List[str], object_Type: str):


### PR DESCRIPTION
This prevent race conditions.

- get attributes is always serializable.
- Clear directory operations are always serializable
- adding retries to functions with `ConsistancyLevel == 'Serializable'`
- the default `ConsistancyLevel == 'Eventually'` if not specified.
- retries are used if serializable 
- gitlab will only run API tests
- moved cd_read_retry_parameters
- removed unused _set_policy_with_retry