### PR TITLE
Remove policy ID

### DIFF
--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -14,14 +14,13 @@ import os
 from collections import namedtuple, defaultdict
 from datetime import datetime
 from enum import Enum, auto
-from json import JSONDecodeError
 from typing import Iterator, Any, Tuple, Dict, List, Callable, Optional, Union, Type
 
 from dcplib.aws import clients as aws_clients
 
 from fusillade import Config
 from fusillade.errors import FusilladeException, FusilladeHTTPException, FusilladeNotFoundException, \
-    AuthorizationException, FusilladeLimitException, FusilladeBindingException, FusilladeBadRequestException
+    AuthorizationException, FusilladeLimitException, FusilladeBadRequestException
 from fusillade.utils.retry import retry
 
 logger = logging.getLogger(__name__)

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -1259,19 +1259,8 @@ class PolicyMixin:
             except cd_client.exceptions.ResourceNotFoundException:
                 raise FusilladeNotFoundException(detail="Resource does not exist.")
             else:
-                _statement = self._set_policy_id(statement, self.name)
-                self._verify_statement(_statement)
-                self._set_policy(_statement, policy_type)
-
-    @classmethod
-    def _set_policy_id(cls, statement: str, object_name: str) -> str:
-        try:
-            s = json.loads(statement)
-        except JSONDecodeError as ex:
-            raise FusilladeBindingException(detail=f"JSONDecodeError: {ex}")
-        policy_id = ':'.join([cls.object_type, object_name])
-        s['Id'] = policy_id
-        return json.dumps(s)
+                self._verify_statement(statement)
+                self._set_policy(statement, policy_type)
 
     def _set_policy(self, statement: str, policy_type: str):
         params = [
@@ -1342,7 +1331,6 @@ class CreateMixin(PolicyMixin):
                creator=None) -> Type['CloudNode']:
         if not statement:
             statement = get_json_file(cls._default_policy_path)
-        statement = cls._set_policy_id(statement, name)
         cls._verify_statement(statement)
         _creator = creator if creator else "fusillade"
         try:

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -36,33 +36,33 @@ class TestGroup(unittest.TestCase):
         with self.subTest("The group is returned when the group has been created with default valid statement"):
             group = Group.create("new_group2")
             self.assertEqual(group.name, "new_group2")
-            self.assertEqual(group.get_policy(), group._set_policy_id(self.default_group_statement, group.name))
+            self.assertEqual(group.get_policy(), self.default_group_statement)
 
         with self.subTest("The group is returned when the group has been created with specified valid statement."):
             group_name = "NewGroup1234"
             statement = create_test_statement(group_name)
             group = Group.create("new_group3", statement)
             self.assertEqual(group.name, "new_group3")
-            self.assertEqual(group.get_policy(), group._set_policy_id(statement, group.name))
+            self.assertEqual(group.get_policy(), statement)
 
     def test_policy(self):
         group = Group.create("new_group")
         with self.subTest("Only one policy is attached when lookup policy is called on a group without any roles"):
             policies = group.get_authz_params()['policies']
             self.assertEqual(len(policies), 1)
-            self.assertEqual(policies[0], group._set_policy_id(self.default_group_statement, group.name))
+            self.assertEqual(policies[0], self.default_group_statement)
 
         group_name = "NewGroup1234"
         statement = create_test_statement(group_name)
         with self.subTest("The group policy changes when satement is set"):
             group.set_policy(statement)
             policies = group.get_authz_params()['policies']
-            self.assertEqual(policies[0], group._set_policy_id(statement, group.name))
+            self.assertEqual(policies[0], statement)
 
         with self.subTest("error raised when invalid statement assigned to group.get_policy()."):
             with self.assertRaises(FusilladeHTTPException):
                 group.set_policy("invalid statement")
-            self.assertEqual(policies[0], group._set_policy_id(statement, group.name))
+            self.assertEqual(policies[0], statement)
 
     def test_users(self):
         emails = ["test@test.com", "why@not.com", "hello@world.com"]
@@ -108,8 +108,7 @@ class TestGroup(unittest.TestCase):
             self.assertEqual(len(group.roles), 2)
         with self.subTest("policies inherited from roles are returned when lookup policies is called"):
             group_policies = sorted(group.get_authz_params()['policies'])
-            role_policies = sorted([role.get_policy() for role in role_objs] + [group._set_policy_id(
-                self.default_group_statement, group.name)])
+            role_policies = sorted([role.get_policy() for role in role_objs] + [self.default_group_statement])
             self.assertListEqual(group_policies, role_policies)
 
 

--- a/tests/test_role_api.py
+++ b/tests/test_role_api.py
@@ -55,7 +55,7 @@ class TestRoleApi(BaseAPITest, unittest.TestCase):
         self.assertEqual(200, resp.status_code)
         expected_body = {
             'role_id': role_id,
-            'policies': {"IAMPolicy": Role(role_id)._set_policy_id(policy, role_id)}
+            'policies': {"IAMPolicy": policy}
         }
         self.assertEqual(expected_body, json.loads(resp.body))
 
@@ -72,7 +72,7 @@ class TestRoleApi(BaseAPITest, unittest.TestCase):
         self.assertEqual(200, resp.status_code)
         expected_body = {
             'role_id': role_id,
-            'policies': {"IAMPolicy": Role(role_id)._set_policy_id(policy, role_id)}
+            'policies': {"IAMPolicy": policy}
         }
         self.assertEqual(expected_body, json.loads(resp.body))
 
@@ -224,7 +224,7 @@ class TestRoleApi(BaseAPITest, unittest.TestCase):
         ])
         policy = create_test_statement("test_role")
         role = Role.create(role_id, policy)
-        expected_policy = role._set_policy_id(policy, role.name)
+        expected_policy = policy
         [Role.create(role_id, policy) for role_id, _ in TEST_NAMES_POS]
         for test in tests:
             with self.subTest(test['name']):

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -31,7 +31,7 @@ class TestRole(unittest.TestCase):
             role_name = "test_role_default"
             role = Role.create(role_name)
             self.assertEqual(role.name, role_name)
-            self.assertEqual(role.get_policy(), role._set_policy_id(self.default_role_statement, role.name))
+            self.assertEqual(role.get_policy(), self.default_role_statement)
 
     def test_role_statement(self):
         role_name = "test_role_specified"
@@ -41,17 +41,17 @@ class TestRole(unittest.TestCase):
             self.assertEqual(role.name, role_name)
 
         with self.subTest("a roles statement is retrieved when role.get_policy() is called"):
-            self.assertEqual(role.get_policy(), role._set_policy_id(statement, role.name))
+            self.assertEqual(role.get_policy(), statement)
 
         with self.subTest("a roles statement is changed when role.get_policy() is assigned"):
             statement = create_test_statement(f"UserPolicySomethingElse")
             role.set_policy(statement)
-            self.assertEqual(role.get_policy(), role._set_policy_id(statement, role.name))
+            self.assertEqual(role.get_policy(), statement)
 
         with self.subTest("Error raised when setting policy to an invalid statement"):
             with self.assertRaises(FusilladeHTTPException):
                 role.set_policy("Something else")
-            self.assertEqual(role.get_policy(), role._set_policy_id(statement, role.name))
+            self.assertEqual(role.get_policy(), statement)
 
         with self.subTest("an error is returned when a policy exceed 10 Kb"):
             statement = create_test_statements(150)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -19,8 +19,8 @@ class TestUser(unittest.TestCase):
         cls.directory, cls.schema_arn = new_test_directory()
         cls.default_policy = get_json_file(default_user_policy_path)
         cls.default_user_policies = sorted([
-            Role._set_policy_id(get_json_file(default_user_role_path), 'default_user'),
-            Group._set_policy_id(get_json_file(default_group_policy_path), 'user_default')
+            get_json_file(default_user_role_path),
+           get_json_file(default_group_policy_path)
         ])
 
     @classmethod
@@ -85,7 +85,7 @@ class TestUser(unittest.TestCase):
 
         with self.subTest("A user inherits the groups policies when joining a group"):
             policies = set(user.get_authz_params()['policies'])
-            expected_policies = set([Group._set_policy_id(*i[::-1]) for i in test_groups])
+            expected_policies = set([i[1] for i in test_groups])
             expected_policies.update(self.default_user_policies)
             self.assertEqual(policies, expected_policies)
 
@@ -119,14 +119,14 @@ class TestUser(unittest.TestCase):
         statement = create_test_statement(f"UserPolicySomethingElse")
         user.set_policy(statement)
         with self.subTest("The user policy is set when statement setter is used."):
-            expected_statement = user._set_policy_id(statement, user.name)
+            expected_statement = statement
             self.assertEqual(user.get_policy(), expected_statement)
             self.assertIn(expected_statement, user.get_authz_params()['policies'])
 
         statement = create_test_statement(f"UserPolicySomethingElse2")
         user.set_policy(statement)
         with self.subTest("The user policy changes when set_policy is used."):
-            expected_statement = user._set_policy_id(statement, user.name)
+            expected_statement = statement
             self.assertEqual(user.get_policy(), expected_statement)
             self.assertIn(expected_statement, user.get_authz_params()['policies'])
 
@@ -154,7 +154,7 @@ class TestUser(unittest.TestCase):
         roles = [Role.create(*i).name for i in test_roles]
         role_names, _ = zip(*test_roles)
         role_names = sorted(role_names)
-        role_statements = [Role._set_policy_id(*i[::-1]) for i in test_roles]
+        role_statements = [i[1] for i in test_roles]
 
         user = User.provision_user(name)
         user_role_names = [Role(None, role).name for role in user.roles]
@@ -181,7 +181,7 @@ class TestUser(unittest.TestCase):
         with self.subTest("A user inherits a roles policies when a role is added to a user."):
             authz_params = user.get_authz_params()
             self.assertListEqual(sorted(authz_params['policies']),
-                                 sorted([user.get_policy(), Role._set_policy_id(role_statement, role_name),
+                                 sorted([user.get_policy(), role_statement,
                                          *self.default_user_policies]))
 
         with self.subTest("A role is removed from user when remove role is called."):
@@ -216,12 +216,12 @@ class TestUser(unittest.TestCase):
         [Group.create(*i) for i in test_groups]
         group_names, _ = zip(*test_groups)
         group_names = sorted(group_names)
-        group_statements = [Group._set_policy_id(*i[::-1]) for i in test_groups]
+        group_statements = [i[1] for i in test_groups]
         test_roles = [(f"role_{i}", create_test_statement(f"RolePolicy{i}")) for i in range(5)]
         [Role.create(*i) for i in test_roles]
         role_names, _ = zip(*test_roles)
         role_names = sorted(role_names)
-        role_statements = [Role._set_policy_id(*i[::-1]) for i in test_roles]
+        role_statements = [i[1] for i in test_roles]
 
         user.add_roles(role_names)
         user.add_groups(group_names)


### PR DESCRIPTION
This feature is no longer used. Facet attribute policy.type as replaced it.