### PR TITLE
Storing github api token in AWS secrets

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,9 @@ stages:
   - test
   - deploy
   - integration_test
+  - promote_integration
+  - promote_staging
+  - promote_prod
 
 before_script:
   - virtualenv ~/venv
@@ -61,3 +64,24 @@ integration_test:
     - staging
   except:
     - schedules
+
+promote_integration:
+  stage: promote_integration
+  script:
+    - ./scripts/promote.py integration --auto
+  only:
+    - master
+
+promote_staging:
+  stage: promote_staging
+  script:
+    - ./scripts/promote.py staging --auto
+  only:
+    - integration
+
+promote_production:
+  stage: promote_prod
+  script:
+    - ./scripts/promote.py production --auto
+  only:
+    - staging

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,8 +10,6 @@ stages:
   - deploy
   - integration_test
   - promote_integration
-  - promote_staging
-  - promote_prod
 
 before_script:
   - virtualenv ~/venv
@@ -71,17 +69,3 @@ promote_integration:
     - ./scripts/promote.py integration --auto
   only:
     - master
-
-promote_staging:
-  stage: promote_staging
-  script:
-    - ./scripts/promote.py staging --auto
-  only:
-    - integration
-
-promote_production:
-  stage: promote_prod
-  script:
-    - ./scripts/promote.py production --auto
-  only:
-    - staging

--- a/environment
+++ b/environment
@@ -42,6 +42,8 @@ JSON_LOGS=False
 AWS_SDK_LOAD_CONFIG=1 # Needed for Terraform to correctly use AWS assumed roles
 
 GITHUB_TOKEN_PATH=None
+GITHUB_TOKEN_SECRET_NAME=dcp/fus/github_deployment_token
+
 # Used for publishing releases.
 
 # tags for AWS resources


### PR DESCRIPTION
Storing github api token in AWS secrets

In order to support CICD a github api token can be stored in AWS Secrets manager and retrieved when promoting a git branch. Set the new environment variable GITHUB_TOKEN_SECRET_NAME to the corresponding AWS secret_id.

- Adding gitlab jobs to promote code to integration