### PR TITLE
Check if user, groups, and roles exist before trying to link

### DIFF
--- a/fusillade/api/_helper.py
+++ b/fusillade/api/_helper.py
@@ -1,6 +1,6 @@
 import requests
 
-from fusillade.clouddirectory import cd_client
+from fusillade.clouddirectory import cd_client, Group, Role
 from fusillade.errors import FusilladeLimitException, FusilladeHTTPException
 
 
@@ -11,6 +11,7 @@ def _modify_roles(cloud_node, request):
             f'{cloud_node.object_type}_id': cloud_node.name
             }
     try:
+        Role.exists(request.json['roles'])
         if action == 'add':
             cloud_node.add_roles(request.json['roles'])
         elif action == 'remove':
@@ -31,6 +32,7 @@ def _modify_groups(cloud_node, request):
             f'{cloud_node.object_type}_id': cloud_node.name
             }
     try:
+        Group.exists(request.json['groups'])
         if action == 'add':
             cloud_node.add_groups(request.json['groups'])
         elif action == 'remove':

--- a/fusillade/api/users/__init__.py
+++ b/fusillade/api/users/__init__.py
@@ -1,20 +1,18 @@
-import requests
 from flask import request, make_response, jsonify
 
 from fusillade import User
 from fusillade.api._helper import _modify_roles, _modify_groups
 from fusillade.api.paging import get_next_token, get_page
-from fusillade.errors import FusilladeLimitException, FusilladeHTTPException
 from fusillade.utils.authorize import authorize
 
 
 @authorize(['fus:PostUser'], ['arn:hca:fus:*:*:user'])
 def post_user(token_info: dict):
     json_body = request.json
-    user = User.provision_user(json_body['user_id'], statement=json_body.get('policy'),
-                               creator=token_info['https://auth.data.humancellatlas.org/email'])
-    user.add_roles(json_body.get('roles', []))
-    user.add_groups(json_body.get('groups', []))
+    User.provision_user(json_body['user_id'], statement=json_body.get('policy'),
+                        creator=token_info['https://auth.data.humancellatlas.org/email'],
+                        groups=json_body.get('groups', []),
+                        roles=json_body.get('roles', []))
     return make_response(jsonify({'msg': f"{json_body['user_id']} created."}), 201)
 
 

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -1594,7 +1594,7 @@ class User(CloudNode, RolesMixin, PolicyMixin, OwnershipMixin):
                     operations.append(directory.batch_get_object_info(Group(group).object_ref))
             directory.batch_read(operations)
         except cd_client.exceptions.ResourceNotFoundException:
-            FusilladeBadRequestException(f"One or more groups or roles does not exist.")
+            raise FusilladeBadRequestException(f"One or more groups or roles does not exist.")
         if statement:
             user._verify_statement(statement)
 


### PR DESCRIPTION
Adding function cloud_node.exists to check if a node exist in cloud directory before try to modify its relationship to other nodes. This fixes #222 