### PR TITLE
gitlab deploys staging and testing environments

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,8 +43,13 @@ unit_tests:
   only:
     - master
 
-deploy:
+.deploy:
   stage: deploy
+  except:
+    - schedules
+
+deploy_branch:
+  extends: .deploy
   script:
     - scripts/populate_deployment_environment.py $CI_COMMIT_REF_NAME -p > environment.local
     - make deploy
@@ -52,8 +57,14 @@ deploy:
     - master
     - integration
     - staging
-  except:
-    - schedules
+
+deploy_name:
+  extends: .deploy
+  script:
+    - scripts/populate_deployment_environment.py testing -p > environment.local
+    - make deploy
+  only:
+    - staging
 
 integration_test:
   stage: integration_test


### PR DESCRIPTION
A new deployment of fusillade name testing has been created for developers to test against. It mirror the deployment on staging. This change keeps testing in sync with staging by deploying testing when ever staging is deployed.