### PR TITLE
Adding Delete Role and Groups API Endpoints

### DIFF
--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -794,6 +794,23 @@ paths:
           description: Unexpected error
       tags:
         - role
+    delete:
+      summary: Remove Role from the system.
+      description: Remove the role from all users and groups, and finally delete the role.
+      operationId: fusillade.api.roles.delete_role
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/role_id'
+      responses:
+        200:
+          description: Role was deleted
+        401:
+          $ref: '#/components/responses/401'
+        default:
+          description: Unexpected error
+      tags:
+        - role
   /v1/role/{role_id}/policy:
     put:
       summary: Modify policy

--- a/fusillade/api/groups/__init__.py
+++ b/fusillade/api/groups/__init__.py
@@ -57,4 +57,5 @@ def put_groups_roles(token_info: dict, group_id: str):
 
 @authorize(['fus:DeleteGroup'], ['arn:hca:fus:*:*:group/{group_id}/'], ['group_id'], {'fus:group_id': 'group_id'})
 def delete_group(token_info: dict, group_id):
-    pass
+    Group(group_id).delete_node()
+    return make_response(f"{group_id} deleted.", 200)

--- a/fusillade/api/roles/__init__.py
+++ b/fusillade/api/roles/__init__.py
@@ -30,3 +30,9 @@ def put_role_policy(token_info: dict, role_id: str):
     role = Role(role_id)
     role.set_policy(request.json['policy'])
     return make_response('Role policy updated.', 200)
+
+
+@authorize(['fus:DeleteRole'], ['arn:hca:fus:*:*:role/{role_id}/'], ['role_id'])
+def delete_role(token_info: dict, role_id):
+    Role(role_id).delete_node()
+    return make_response(f"{role_id} deleted.", 200)

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -640,21 +640,35 @@ class CloudDirectory:
         See details on deletion requirements for more info
         https://docs.aws.amazon.com/clouddirectory/latest/developerguide/directory_objects_access_objects.html
         """
-        [self.delete_policy(policy_ref) for policy_ref in self.list_object_policies(
-            obj_ref, ConsistencyLevel=ConsistencyLevel.SERIALIZABLE.name)]
-        self.batch_write(
-            [self.batch_detach_object(parent_ref, link_name) for parent_ref, link_name in self.list_object_parents(
-                obj_ref, ConsistencyLevel=ConsistencyLevel.SERIALIZABLE.name)])
-        self.batch_write([self.batch_detach_typed_link(i) for i in self.list_incoming_typed_links(
-            object_ref=obj_ref,
-            ConsistencyLevel=ConsistencyLevel.SERIALIZABLE.name
-        )])
-        self.batch_write([self.batch_detach_typed_link(i) for i in self.list_outgoing_typed_links(
-            obj_ref,
-            ConsistencyLevel=ConsistencyLevel.SERIALIZABLE.name)])
+        object_id = f"${self.get_object_information(obj_ref)['ObjectIdentifier']}"
+        params = dict(object_ref=object_id, ConsistencyLevel=ConsistencyLevel.SERIALIZABLE.name)
+        [self.delete_policy(policy_ref) for policy_ref in self.list_object_policies(**params)]
+        self.batch_write([
+            self.batch_detach_object(parent_ref, link_name)
+            for parent_ref, link_name in
+            self.list_object_parents(**params)])
+        self.batch_write([
+            self.batch_detach_object(parent_ref, link_name)
+            for parent_ref, link_name in
+            self.list_object_parents(**params)])
+        self.batch_write([
+            self.batch_detach_typed_link(i)
+            for i in
+            self.list_incoming_typed_links(**params)])
+        self.batch_write([
+            self.batch_detach_typed_link(i)
+            for i in
+            self.list_outgoing_typed_links(**params)])
+        try:
+            self.batch_write([
+                self.batch_detach_object(object_id, link_name)
+                for link_name, _ in
+                self.list_object_children(**params)])
+        except cd_client.exceptions.NotNodeException:
+            pass
         retry(**cd_read_retry_parameters)(cd_client.delete_object)(
             DirectoryArn=self._dir_arn,
-            ObjectReference={'Selector': obj_ref})
+            ObjectReference={'Selector': object_id})
 
     @staticmethod
     def batch_detach_policy(policy_ref: str, object_ref: str):
@@ -1174,6 +1188,12 @@ class CloudNode:
         except cd_client.exceptions.ResourceNotFoundException:
             raise FusilladeNotFoundException(detail="Resource does not exist.")
         return dict([(attr['Key']['Name'], attr['Value'].popitem()[1]) for attr in resp['Attributes']])
+
+    def delete_node(self):
+        try:
+            self.cd.delete_object(self.object_ref)
+        except cd_client.exceptions.ResourceNotFoundException:
+            raise FusilladeNotFoundException(f"Failed to delete {self.name}. {self.object_type} does not exist.")
 
     @classmethod
     def list_all(cls, next_token: str, per_page: int):

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -648,10 +648,6 @@ class CloudDirectory:
             for parent_ref, link_name in
             self.list_object_parents(**params)])
         self.batch_write([
-            self.batch_detach_object(parent_ref, link_name)
-            for parent_ref, link_name in
-            self.list_object_parents(**params)])
-        self.batch_write([
             self.batch_detach_typed_link(i)
             for i in
             self.list_incoming_typed_links(**params)])


### PR DESCRIPTION
- Adding DELETE /v1/role/{role_id} endpoint
- Adding DELETE /v1/group/{group_id} endpoint
- Added detaching of children from parents in Clouddirectory.delete_object to allow Roles to be deleted
- Clouddirectory.delete_object uses the object_identifier to delete objects, otherwise the object reference we provide will be deleted before the object is deleted. The object_identifier provide a direct link to the object.
