### PR TITLE
Return more info from evaluate endpoint

### DIFF
--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -237,7 +237,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  decision:
+                  result:
                     type: boolean
         default:
           description: Unexpected error

--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -239,6 +239,8 @@ paths:
                 properties:
                   result:
                     type: boolean
+                  reason:
+                    type: string
         default:
           description: Unexpected error
   /v1/users:

--- a/fusillade/api/evaluate.py
+++ b/fusillade/api/evaluate.py
@@ -5,7 +5,7 @@ from threading import Thread
 from flask import make_response, jsonify
 
 from fusillade import User
-from fusillade.errors import AuthorizationException, FusilladeForbiddenException
+from fusillade.errors import AuthorizationException
 from fusillade.utils.authorize import assert_authorized, evaluate_policy, restricted_context_entries, get_email_claim
 
 
@@ -17,14 +17,15 @@ def evaluate_policy_api(token_info, body):  # TODO allow context variables to be
         try:
             authz_params = User(body['principal']).get_authz_params()
         except AuthorizationException:
-            response = {'result': False, 'msg': "The user is disabled."}
+            response = {'result': False, 'reason': "The user is disabled."}
         else:
-            response = evaluate_policy(body['principal'],
-                                     body['action'],
-                                     body['resource'],
-                                     authz_params['policies'],
-                                     context_entries=restricted_context_entries(authz_params))
-    return make_response(jsonify(**body, **response), 200)
+            response = evaluate_policy(
+                body['principal'],
+                body['action'],
+                body['resource'],
+                authz_params['policies'],
+                context_entries=restricted_context_entries(authz_params))
+    return make_response(jsonify(**response), 200)
 
 
 class AuthorizeThread:

--- a/fusillade/api/evaluate.py
+++ b/fusillade/api/evaluate.py
@@ -17,14 +17,14 @@ def evaluate_policy_api(token_info, body):  # TODO allow context variables to be
         try:
             authz_params = User(body['principal']).get_authz_params()
         except AuthorizationException:
-            result = False
+            response = {'result': False}
         else:
-            result = evaluate_policy(body['principal'],
+            response = evaluate_policy(body['principal'],
                                      body['action'],
                                      body['resource'],
                                      authz_params['policies'],
                                      context_entries=restricted_context_entries(authz_params))
-    return make_response(jsonify(**body, result=result), 200)
+    return make_response(jsonify(**body, **response), 200)
 
 
 class AuthorizeThread:

--- a/fusillade/api/evaluate.py
+++ b/fusillade/api/evaluate.py
@@ -17,7 +17,7 @@ def evaluate_policy_api(token_info, body):  # TODO allow context variables to be
         try:
             authz_params = User(body['principal']).get_authz_params()
         except AuthorizationException:
-            response = {'result': False}
+            response = {'result': False, 'msg': "The user is disabled."}
         else:
             response = evaluate_policy(body['principal'],
                                      body['action'],

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -882,6 +882,13 @@ class CloudDirectory:
     def get_policies(self,
                      policy_paths: List[Dict[str, Any]],
                      policy_type='IAMPolicy') -> Dict[str, Union[List[Dict[str, str]], List[str]]]:
+        """
+        Get's policy statements and attributes.
+
+        :param policy_paths: a list of paths leading to policy nodes stored in cloud directory
+        :param policy_type: the type of policies to retrieve from the policy nodes
+        :return: returns the policies of the type IAMPolicy from a list of policy paths.
+        """
         # Parse the policyIds from the policies path. Only keep the unique ids
         policy_ids = set(
             [
@@ -892,7 +899,7 @@ class CloudDirectory:
             ]
         )
 
-        # retrieve the policies in a single request
+        # retrieve the policies and policy attributes in a batched request
         operations = []
         for policy_id in policy_ids:
             operations.extend([
@@ -917,7 +924,7 @@ class CloudDirectory:
                     }
                 }])
 
-        # parse the policies from the responses
+        # parse the policies and attributes from the responses
         responses = cd_client.batch_read(DirectoryArn=self._dir_arn, Operations=operations)['Responses']
         results = defaultdict(list)
         n = 2

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -939,7 +939,7 @@ class CloudDirectory:
                         'name': name
                     }
                 )
-                results[_type] = name
+                results[f'{_type}s'].append(name)
             except KeyError:
                 results.append(
                     {

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -894,7 +894,7 @@ class CloudDirectory:
 
         # retrieve the policies in a single request
         operations = []
-        [
+        for policy_id in policy_ids:
             operations.extend([
                 {
                     'GetObjectAttributes': {
@@ -916,8 +916,6 @@ class CloudDirectory:
                         'AttributeNames': ['name', 'type']
                     }
                 }])
-            for policy_id in policy_ids
-        ]
 
         # parse the policies from the responses
         responses = cd_client.batch_read(DirectoryArn=self._dir_arn, Operations=operations)['Responses']

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -7,7 +7,6 @@ https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloud
 """
 import functools
 import hashlib
-import itertools
 import json
 import logging
 import os
@@ -16,8 +15,9 @@ from datetime import datetime
 from enum import Enum, auto
 from typing import Iterator, Any, Tuple, Dict, List, Callable, Optional, Union, Type
 
-from dcplib.aws import clients as aws_clients
+import itertools
 
+from dcplib.aws import clients as aws_clients
 from fusillade import Config
 from fusillade.errors import FusilladeException, FusilladeHTTPException, FusilladeNotFoundException, \
     AuthorizationException, FusilladeLimitException, FusilladeBadRequestException
@@ -879,7 +879,8 @@ class CloudDirectory:
             **kwargs
         )
 
-    def get_policies(self, policy_paths: List[Dict[str, Any]], policy_type='IAMPolicy') -> Dict[str, List[str]]:
+    def get_policies(self, policy_paths: List[Dict[str, Any]], policy_type='IAMPolicy') -> Dict[str, Union[List[Dict[
+        str, str]], List[str]]]:
         # Parse the policyIds from the policies path. Only keep the unique ids
         policy_ids = set(
             [
@@ -891,54 +892,63 @@ class CloudDirectory:
         )
 
         # retrieve the policies in a single request
-        operations = [
-            {
-                'GetObjectAttributes': {
-                    'ObjectReference': {'Selector': f'${policy_id}'},
-                    'SchemaFacet': {
-                        'SchemaArn': self.node_schema,
-                        'FacetName': 'POLICY'
-                    },
-                    'AttributeNames': ['policy_document']
-                }
-            }
+        operations = []
+        [
+            operations.extend([
+                {
+                    'GetObjectAttributes': {
+                        'ObjectReference': {'Selector': f'${policy_id}'},
+                        'SchemaFacet': {
+                            'SchemaArn': self.node_schema,
+                            'FacetName': 'POLICY'
+                        },
+                        'AttributeNames': ['policy_document']
+                    }
+                },
+                {
+                    'GetObjectAttributes': {
+                        'ObjectReference': {'Selector': f'${policy_id}'},
+                        'SchemaFacet': {
+                            'SchemaArn': self._schema,
+                            'FacetName': 'IAMPolicy'
+                        },
+                        'AttributeNames': ['name', 'type']
+                    }
+                }])
             for policy_id in policy_ids
         ]
-        operations.extend([
-            {
-                'GetObjectAttributes': {
-                    'ObjectReference': {'Selector': f'${policy_id}'},
-                    'SchemaFacet': {
-                        'SchemaArn': self._schema,
-                        'FacetName': 'IAMPolicy'
-                    },
-                    'AttributeNames': ['name', 'type']
-                }
-            }
-            for policy_id in policy_ids
-        ])
 
         # parse the policies from the responses
         responses = cd_client.batch_read(DirectoryArn=self._dir_arn, Operations=operations)['Responses']
-        middle = len(responses) // 2
         results = defaultdict(list)
-        results['policies'].extend([
-            response['SuccessfulResponse']['GetObjectAttributes']['Attributes'][0]['Value']['BinaryValue'].decode(
-                'utf-8')
-            for response in responses[:middle]]
-        )
-        for response in responses[middle:]:
+        n = 2
+        for p, a in [responses[i:i + n] for i in range(0, len(responses), n)]:
+            policy = p['SuccessfulResponse']['GetObjectAttributes']['Attributes'][0]['Value'][
+                'BinaryValue'].decode('utf-8')
             try:
-                attrs = response['SuccessfulResponse']['GetObjectAttributes']['Attributes']
+                attrs = a['SuccessfulResponse']['GetObjectAttributes']['Attributes']
                 if attrs[0]['Key']['Name'] == 'name':
                     name = attrs[0]['Value']['StringValue']
                     _type = attrs[1]['Value']['StringValue']
                 else:
                     name = attrs[1]['Value']['StringValue']
                     _type = attrs[0]['Value']['StringValue']
+                results['policies'].append(
+                    {
+                        'policy': policy,
+                        'type': _type,
+                        'name': name
+                    }
+                )
+                results[_type] = name
             except KeyError:
-                continue
-            results[_type].append(name)
+                results.append(
+                    {
+                        'policy': policy,
+                        'type': None,
+                        'name': None
+                    }
+                )
         return results
 
     @retry(**cd_read_retry_parameters)
@@ -1227,7 +1237,7 @@ class PolicyMixin:
     """Adds policy support to a cloudNode"""
     allowed_policy_types = ['IAMPolicy']
 
-    def get_authz_params(self) -> Dict[str, List[str]]:
+    def get_authz_params(self) -> Dict[str, Union[List[Dict[str, str]], List[str]]]:
         policy_paths = self.cd.lookup_policy(self.object_ref)
         return self.cd.get_policies(policy_paths)
 
@@ -1517,7 +1527,7 @@ class User(CloudNode, RolesMixin, PolicyMixin, OwnershipMixin):
         self._groups: Optional[List[str]] = None
         self._roles: Optional[List[str]] = None
 
-    def get_authz_params(self) -> Dict[str, List[str]]:
+    def get_authz_params(self) -> Dict[str, Union[List[Dict[str, str]], List[str]]]:
         if self.is_enabled():
             policy_paths = self.lookup_policies_batched()
         else:

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -879,8 +879,9 @@ class CloudDirectory:
             **kwargs
         )
 
-    def get_policies(self, policy_paths: List[Dict[str, Any]], policy_type='IAMPolicy') -> Dict[str, Union[List[Dict[
-        str, str]], List[str]]]:
+    def get_policies(self,
+                     policy_paths: List[Dict[str, Any]],
+                     policy_type='IAMPolicy') -> Dict[str, Union[List[Dict[str, str]], List[str]]]:
         # Parse the policyIds from the policies path. Only keep the unique ids
         policy_ids = set(
             [

--- a/fusillade/utils/authorize.py
+++ b/fusillade/utils/authorize.py
@@ -61,7 +61,7 @@ def evaluate_policy(
     elif 'allowed' in eval_decisions:
         response = {
             'result': True,
-            'reason': 'Permission is allowed denied.',
+            'reason': 'Permission is allowed.',
         }
     else:
         response = {

--- a/fusillade/utils/authorize.py
+++ b/fusillade/utils/authorize.py
@@ -11,7 +11,14 @@ iam = aws_clients.iam
 simulate_custom_policy_paginator = iam.get_paginator('simulate_custom_policy')
 
 
-def get_policy_statement(evaluation_results, policies):
+def get_policy_statement(evaluation_results: List[Dict[str, Any]], policies: List[str]) -> List[Dict[str, Any]]:
+    """
+    Parses the response from simulate_custom_policy and adds the policy statements that matched to the results.
+
+    :param evaluation_results:
+    :param policies:
+    :return:
+    """
     for evaluation_result in evaluation_results:
         for ms in evaluation_result['MatchedStatements']:
             policy_index = int(ms['SourcePolicyId'].split('.')[-1]) - 1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,7 +38,7 @@ class TestApi(BaseAPITest, unittest.TestCase):
             {
                 'json_request_body': {
                     "action": ["fus:GetUser"],
-                    "resource": [f"arn:hca:fus:*:*:user/{email}"],
+                    "resource": [f"arn:hca:fus:*:*:user/{email}/policy"],
                     "principal": email
                 },
                 'response': {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,7 +38,7 @@ class TestApi(BaseAPITest, unittest.TestCase):
             {
                 'json_request_body': {
                     "action": ["fus:GetUser"],
-                    "resource": [f"arn:hca:fus:*:*:user/{email}/policy"],
+                    "resource": [f"arn:hca:fus:*:*:user/{email}"],
                     "principal": email
                 },
                 'response': {

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -48,21 +48,20 @@ class TestGroup(unittest.TestCase):
     def test_policy(self):
         group = Group.create("new_group")
         with self.subTest("Only one policy is attached when lookup policy is called on a group without any roles"):
-            policies = group.get_authz_params()['policies']
+            policies = [p['policy'] for p in group.get_authz_params()['policies']]
             self.assertEqual(len(policies), 1)
-            self.assertEqual(policies[0]['policy'], self.default_group_statement)
+            self.assertEqual(policies[0], self.default_group_statement)
 
         group_name = "NewGroup1234"
         statement = create_test_statement(group_name)
         with self.subTest("The group policy changes when satement is set"):
             group.set_policy(statement)
-            policies = group.get_authz_params()['policies']
-            self.assertEqual(policies[0]['policy'], statement)
+            policies = [p['policy'] for p in group.get_authz_params()['policies']]
+            self.assertEqual(policies[0], statement)
 
         with self.subTest("error raised when invalid statement assigned to group.get_policy()."):
             with self.assertRaises(FusilladeHTTPException):
                 group.set_policy("invalid statement")
-            self.assertEqual(policies[0]['policy'], statement)
 
     def test_users(self):
         emails = ["test@test.com", "why@not.com", "hello@world.com"]
@@ -107,7 +106,7 @@ class TestGroup(unittest.TestCase):
             group.add_roles(roles)
             self.assertEqual(len(group.roles), 2)
         with self.subTest("policies inherited from roles are returned when lookup policies is called"):
-            group_policies = sorted([authz_params['policy'] for authz_params in group.get_authz_params()['policies']])
+            group_policies = sorted([p['policy'] for p in group.get_authz_params()['policies']])
             role_policies = sorted([role.get_policy() for role in role_objs] + [self.default_group_statement])
             self.assertListEqual(group_policies, role_policies)
 

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -50,19 +50,19 @@ class TestGroup(unittest.TestCase):
         with self.subTest("Only one policy is attached when lookup policy is called on a group without any roles"):
             policies = group.get_authz_params()['policies']
             self.assertEqual(len(policies), 1)
-            self.assertEqual(policies[0], self.default_group_statement)
+            self.assertEqual(policies[0]['policy'], self.default_group_statement)
 
         group_name = "NewGroup1234"
         statement = create_test_statement(group_name)
         with self.subTest("The group policy changes when satement is set"):
             group.set_policy(statement)
             policies = group.get_authz_params()['policies']
-            self.assertEqual(policies[0], statement)
+            self.assertEqual(policies[0]['policy'], statement)
 
         with self.subTest("error raised when invalid statement assigned to group.get_policy()."):
             with self.assertRaises(FusilladeHTTPException):
                 group.set_policy("invalid statement")
-            self.assertEqual(policies[0], statement)
+            self.assertEqual(policies[0]['policy'], statement)
 
     def test_users(self):
         emails = ["test@test.com", "why@not.com", "hello@world.com"]
@@ -107,7 +107,7 @@ class TestGroup(unittest.TestCase):
             group.add_roles(roles)
             self.assertEqual(len(group.roles), 2)
         with self.subTest("policies inherited from roles are returned when lookup policies is called"):
-            group_policies = sorted(group.get_authz_params()['policies'])
+            group_policies = sorted([authz_params['policy'] for authz_params in group.get_authz_params()['policies']])
             role_policies = sorted([role.get_policy() for role in role_objs] + [self.default_group_statement])
             self.assertListEqual(group_policies, role_policies)
 

--- a/tests/test_role_api.py
+++ b/tests/test_role_api.py
@@ -314,8 +314,8 @@ class TestRoleApi(BaseAPITest, unittest.TestCase):
         role_id = "role_1"
 
         with self.subTest("Role delete with users and groups."):
-            group = "group_0"
-            user = "user_1"
+            group = "group_test_delete_role"
+            user = "user_test_delete_role"
             policy = create_test_statement("policy_04")
 
             resp = self.app.post(f'/v1/role',
@@ -351,7 +351,7 @@ class TestRoleApi(BaseAPITest, unittest.TestCase):
             self.assertNotIn(role_id, roles)
 
         with self.subTest("delete a role that does not exist."):
-            resp = self.app.delete(f'/v1/role/{role_id}', headers=headers)
+            resp = self.app.delete(f'/v1/role/ghost', headers=headers)
             self.assertEqual(resp.status_code, 404)
 
 if __name__ == '__main__':

--- a/tests/test_user_api.py
+++ b/tests/test_user_api.py
@@ -234,7 +234,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
                 'name': "test_put_user_group0@email.com",
                 'action': 'add',
                 'json_request_body': {
-                    "groups": [Group.create("group_0").name]
+                    "groups": [Group.create("test_put_username_groups_0").name]
                 },
                 'responses': [
                     {'code': 200},
@@ -245,7 +245,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
                 'name': "test_put_user_group1@email.com",
                 'action': 'remove',
                 'json_request_body': {
-                    "groups": [Group.create("group_1").name]
+                    "groups": [Group.create("test_put_username_groups_1").name]
                 },
                 'responses': [
                     {'code': 200},
@@ -273,7 +273,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
                 self.assertEqual(test['responses'][1]['code'], resp.status_code)
 
     def test_user_group_limit(self):
-        groups = [Group.create(f"group_{i}").name for i in range(10)]
+        groups = [Group.create(f"test_user_group_limit{i}").name for i in range(10)]
         name = "test_put_user_group0@email.com"
         user = User.provision_user(name)
         tests = [
@@ -321,7 +321,7 @@ class TestUserApi(BaseAPITest, unittest.TestCase):
         user = User.provision_user(name)
         resp = self.app.get(f'/v1/user/{name}/groups', headers=headers)
         self.assertEqual(1, len(json.loads(resp.body)[key]))
-        groups = [Group.create(f"group_{i}").name for i in range(8)]
+        groups = [Group.create(f"test_get_username_groups_{i}").name for i in range(8)]
         user.add_groups(groups)
         self._test_paging(f'/v1/user/{name}/groups', headers, 5, key)
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -47,12 +47,13 @@ class TestUser(unittest.TestCase):
         user = User(name)
         with self.subTest("new user is automatically provisioned on demand with default settings when "
                           "lookup_policy is called for a new user."):
-            self.assertEqual(sorted(user.get_authz_params()['policies']), self.default_user_policies)
+            self.assertEqual(sorted([p['policy'] for p in user.get_authz_params()['policies']]),
+                             self.default_user_policies)
         with self.subTest("error is returned when provision_user is called for an existing user"):
             self.assertRaises(FusilladeHTTPException, user.provision_user, name)
         with self.subTest("an existing users info is retrieved when instantiating User class for an existing user"):
             user = User(name)
-            self.assertEqual(sorted(user.get_authz_params()['policies']), self.default_user_policies)
+            self.assertEqual(sorted([p['policy'] for p in user.get_authz_params()['policies']]), self.default_user_policies)
 
     def test_get_groups(self):
         name = "test_get_groups@test.com"
@@ -84,7 +85,7 @@ class TestUser(unittest.TestCase):
             self.assertEqual(len(user.groups), 6)
 
         with self.subTest("A user inherits the groups policies when joining a group"):
-            policies = set(user.get_authz_params()['policies'])
+            policies = set([p['policy'] for p in user.get_authz_params()['policies']])
             expected_policies = set([i[1] for i in test_groups])
             expected_policies.update(self.default_user_policies)
             self.assertEqual(policies, expected_policies)
@@ -121,14 +122,14 @@ class TestUser(unittest.TestCase):
         with self.subTest("The user policy is set when statement setter is used."):
             expected_statement = statement
             self.assertEqual(user.get_policy(), expected_statement)
-            self.assertIn(expected_statement, user.get_authz_params()['policies'])
+            self.assertIn(expected_statement, [p['policy'] for p in user.get_authz_params()['policies']])
 
         statement = create_test_statement(f"UserPolicySomethingElse2")
         user.set_policy(statement)
         with self.subTest("The user policy changes when set_policy is used."):
             expected_statement = statement
             self.assertEqual(user.get_policy(), expected_statement)
-            self.assertIn(expected_statement, user.get_authz_params()['policies'])
+            self.assertIn(expected_statement, [p['policy'] for p in user.get_authz_params()['policies']])
 
         with self.subTest("Error raised when setting policy to an invalid statement"):
             with self.assertRaises(FusilladeHTTPException):
@@ -179,8 +180,8 @@ class TestUser(unittest.TestCase):
 
         user.set_policy(self.default_policy)
         with self.subTest("A user inherits a roles policies when a role is added to a user."):
-            authz_params = user.get_authz_params()
-            self.assertListEqual(sorted(authz_params['policies']),
+            policies = [p['policy'] for p in user.get_authz_params()['policies']]
+            self.assertListEqual(sorted(policies),
                                  sorted([user.get_policy(), role_statement,
                                          *self.default_user_policies]))
 
@@ -194,8 +195,8 @@ class TestUser(unittest.TestCase):
             self.assertEqual(sorted(user_role_names), role_names)
 
         with self.subTest("A user inherits multiple role policies when the user has multiple roles."):
-            authz_params = user.get_authz_params()
-            self.assertListEqual(sorted(authz_params['policies']),
+            policies = [p['policy'] for p in user.get_authz_params()['policies']]
+            self.assertListEqual(sorted(policies),
                                  sorted([user.get_policy(), *self.default_user_policies, *role_statements]))
 
         with self.subTest("A user's roles are listed when a listing a users roles."):
@@ -232,11 +233,11 @@ class TestUser(unittest.TestCase):
         self.assertListEqual(sorted(user_role_names), role_names)
         self.assertEqual(sorted(user_group_names), group_names + ['user_default'])
         authz_params = user.get_authz_params()
-        self.assertSequenceEqual(sorted(authz_params['policies']), sorted(
+        self.assertSequenceEqual(sorted([p['policy'] for p in authz_params['policies']]), sorted(
             [user.get_policy(), *self.default_user_policies] + group_statements + role_statements)
                                  )
-        self.assertListEqual(sorted(authz_params['role']), sorted(['default_user'] + role_names))
-        self.assertListEqual(sorted(authz_params['group']), sorted(['user_default'] + group_names))
+        self.assertListEqual(sorted(authz_params['roles']), sorted(['default_user'] + role_names))
+        self.assertListEqual(sorted(authz_params['groups']), sorted(['user_default'] + group_names))
 
     def test_ownership(self):
         user = User.provision_user('test_user')


### PR DESCRIPTION
### Test plan
- updated test that use `get_authz_params` to correctly parse the value returned
- improved the naming of test variables to avoid name collisions

### Release notes
- Renamed "decision" to "result" in *fusillade_api.yml*
- The reason for an evaluation result has been added to the response of `v1/policies/evaluate`
- Adding reason to the response when user is disabled
- The specific statement in the policy that cause discussion is returned in the response. This will make it easier to debug new policies.
- Using `iam.get_paginator('simulate_custom_policy')` for policy simulation to retrieve all results 
- policies are returned with the name and type grouped together. This provides better debugging information for the evaluation endpoint.