### PR TITLE
Creating objects in a single batch request

### DIFF
--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -1281,7 +1281,6 @@ class PolicyMixin:
                              ))
         else:
             return operations
-        return policy_ref
 
     def get_policy_name(self, policy_type):
         return self.hash_name(f"{self._path_name}{self.object_type}{policy_type}")

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -53,10 +53,14 @@ class TestRole(unittest.TestCase):
                 role.set_policy("Something else")
             self.assertEqual(role.get_policy(), statement)
 
+        statement = create_test_statements(150)
         with self.subTest("an error is returned when a policy exceed 10 Kb"):
-            statement = create_test_statements(150)
             with self.assertRaises(FusilladeHTTPException) as ex:
                 role.set_policy(statement)
+
+        with self.subTest("an error is returned when a policy exceed 10 Kb"):
+            with self.assertRaises(FusilladeHTTPException) as ex:
+                Role.create("test_role_specified_2", statement)
 
 
 if __name__ == '__main__':

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -54,11 +54,11 @@ class TestRole(unittest.TestCase):
             self.assertEqual(role.get_policy(), statement)
 
         statement = create_test_statements(150)
-        with self.subTest("an error is returned when a policy exceed 10 Kb"):
+        with self.subTest("an error is returned when a policy that exceeds 10 Kb for a pre-existing role"):
             with self.assertRaises(FusilladeHTTPException) as ex:
                 role.set_policy(statement)
 
-        with self.subTest("an error is returned when a policy exceed 10 Kb"):
+        with self.subTest("an error is returned when a policy that exceeds 10 Kb for a new role"):
             with self.assertRaises(FusilladeHTTPException) as ex:
                 Role.create("test_role_specified_2", statement)
 


### PR DESCRIPTION
This prevents a partial object from being created.

This fix applies when users, groups, roles, and associated policy nodes are created. The creation of one of these nodes involves multiple write operations. If a write operation fails in the process of creating a node, the previous write operations must be reversed. Cloud directory automatically reverses write operations performed in a batch write operation if one of the batch operations fail. Node creation has been rolled into a single batch write operation to automate the cleanup of a failed write operations. If one part of the batch_write request fails the rest of the write operations are rolled back. 

- create_policy can return a batch of operations if run==false
- ownershipMixin has batch options
- adding test in test_roles to test error handling in the modified create function

<!--
Please make sure to provide a meaningful title for your PR. 
Do not keep the default title.
-->

<!--
Use GitHub keywords "fixes" or "closes" followed by an issue number if your PR
completely resolves an issue:
"Fixes #123" or "Closes #456"
-->

<!-- 
Describe how you tested this PR, and how you will test the feature after it is
merged. Uncomment below:

### Test plan
-->

<!--
Describe any special instructions to the operator who will deploy your code to
the integration, staging and production deployments. Uncomment below:

### Deployment instructions & migrations
-->

<!-- 
Add notes to highlight the feature when it's released/demoed. Uncomment the
headings below:

### Release notes
-->

<!--
Do you want your PR to be merged by the reviewer using squash or rebase
merging? If so, mention it here.
-->

