### PR TITLE
Running integration tests after the testing deployment has completed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,14 +65,24 @@ deploy_name:
   only:
     - staging
 
-integration_test:
-  stage: integration_test
+.integration_test:
+  stage: .integration_test
   script:
     - scripts/populate_deployment_environment.py $CI_COMMIT_REF_NAME -p > environment.local
     - make integration_test
   only:
     - master
     - integration
+    - staging
+  except:
+    - schedules
+
+integration_test_named:
+  extends: .integration_test
+  script:
+    - scripts/populate_deployment_environment.py testing -p > environment.local
+    - make integration_test
+  only:
     - staging
   except:
     - schedules

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ deploy_name:
     - staging
 
 .integration_test:
-  stage: .integration_test
+  stage: integration_test
   script:
     - scripts/populate_deployment_environment.py $CI_COMMIT_REF_NAME -p > environment.local
     - make integration_test


### PR DESCRIPTION
The testing deployment is deployed at the same time as staging but, only the integration tests for staging were run. This PR adds integration tests to the testing deployment.