### PR TITLE
Adding support for refresh token revoke and silent authentication

### DIFF
--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -108,6 +108,14 @@ paths:
           in: query
           schema:
             type: string
+        - name: nonce
+          in: query
+          schema:
+            type: string
+        - name: prompt
+          in: query
+          schema:
+            type: string
       responses:
         302:
           description: Redirecting to authentication server.
@@ -117,6 +125,23 @@ paths:
                 type: string
         default:
           description: Unexpected error.
+  /oauth/revoke:
+    post:
+      summary: Revoke a refresh token
+      description: Revokes a refresh token from a client making all future token refresh requests fail.
+      operationId: fusillade.api.oauth.revoke
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                client_id:
+                  type: string
+                  description:
+                token:
+                  type: string
+                  description: The refresh token to revoke.
   /oauth/token:
     post:
       summary: Retrieve the authentications token

--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -130,18 +130,27 @@ paths:
       summary: Revoke a refresh token
       description: Revokes a refresh token from a client making all future token refresh requests fail.
       operationId: fusillade.api.oauth.revoke
+      tags:
+        - oauth
       requestBody:
         content:
           application/json:
             schema:
               type: object
+              required:
+                - client_id
+                - token
               properties:
                 client_id:
                   type: string
-                  description:
                 token:
                   type: string
                   description: The refresh token to revoke.
+      responses:
+        200:
+          description: OK.
+        default:
+          description: Unexpected error.
   /oauth/token:
     post:
       summary: Retrieve the authentications token

--- a/fusillade/api/oauth.py
+++ b/fusillade/api/oauth.py
@@ -26,17 +26,11 @@ def authorize():
     query_params = request.args.copy() if request.args else {}
     openid_provider = Config.get_openid_provider()
     query_params["openid_provider"] = openid_provider
+    query_params['response_type'] = "code"
     client_id = query_params.get("client_id")
     client_id = client_id if client_id != 'None' else None
     if client_id:
-        # TODO: audit this
-        auth_params = dict(client_id=query_params["client_id"],
-                           response_type="code",
-                           scope=query_params["scope"],
-                           redirect_uri=query_params["redirect_uri"],
-                           state=query_params["state"])
-        if "audience" in query_params:
-            auth_params["audience"] = query_params["audience"]
+        auth_params = query_params
     else:
         state = base64.b64encode(json.dumps(query_params).encode()).decode()
         # TODO: set random state


### PR DESCRIPTION
- Auth0's revoke endpoint has been passed through to the fusillade API. This is part of the logout functionality coming to fusillade. 

- Added silent authentication for single page web application to take advantage of refresh tokens without require the user to login again.


-  Also simplified authorization flow when client_id is used.