### PR TITLE
Moving IAM out of clouddirectory

### DIFF
--- a/fusillade/api/internal.py
+++ b/fusillade/api/internal.py
@@ -4,6 +4,7 @@ from flask import request
 from furl import furl
 
 from fusillade.config import Config
+from fusillade.utils import authorize
 
 
 def version():
@@ -21,8 +22,9 @@ def version():
 
 def health_check(*args, **kwargs):
     health_checks = dict()
-    health_checks.update(**Config.get_directory().get_health_status(),
-                         **get_openip_health_status())
+    health_checks.update(**Config.get_directory().health_checks(),
+                         **get_openip_health_status(),
+                         **authorize.health_checks())
     if all([check == 'ok' for check in health_checks.values()]):
         body = dict(
             health_status='ok',

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -21,12 +21,12 @@ from dcplib.aws import clients as aws_clients
 from fusillade import Config
 from fusillade.errors import FusilladeException, FusilladeHTTPException, FusilladeNotFoundException, \
     AuthorizationException, FusilladeLimitException, FusilladeBadRequestException
+from fusillade.policy.validator import verify_iam_policy
 from fusillade.utils.retry import retry
 
 logger = logging.getLogger(__name__)
 
 cd_client = aws_clients.clouddirectory
-iam = aws_clients.iam
 project_arn = "arn:aws:clouddirectory:{}:{}:".format(
     os.getenv('AWS_DEFAULT_REGION'),
     aws_clients.sts.get_caller_identity().get('Account'))
@@ -982,36 +982,17 @@ class CloudDirectory:
             **kwargs
         )
 
-    def get_health_status(self) -> dict:
+    def health_checks(self) -> Dict[str, str]:
         """
         Runs a health check on AWS cloud directory and iam policy simulator
         :return: the status of the services.
         """
-        health_status = {}
-        try:
-            iam.simulate_custom_policy(
-                PolicyInputList=[json.dumps({
-                    "Version": "2012-10-17",
-                    "Statement": [{
-                        "Sid": "DefaultRole",
-                        "Effect": "Deny",
-                        "Action": ["fake:action"],
-                        "Resource": "fake:resource"
-                    }]})],
-                ActionNames=["fake:action"],
-                ResourceArns=["arn:aws:iam::123456789012:user/Bob"])
-        except Exception:
-            health_status.update(iam_health_status='unhealthy')
-        else:
-            health_status.update(iam_health_status='ok')
-
         try:
             self.get_object_information('/')['ResponseMetadata']['HTTPStatusCode']
         except Exception:
-            health_status.update(clouddirectory_health_status='unhealthy')
+            return dict(clouddirectory_health_status='unhealthy')
         else:
-            health_status.update(clouddirectory_health_status='ok')
-        return health_status
+            return dict(clouddirectory_health_status='ok')
 
 
 class CloudNode:
@@ -1350,7 +1331,7 @@ class PolicyMixin:
             except cd_client.exceptions.ResourceNotFoundException:
                 raise FusilladeNotFoundException(detail="Resource does not exist.")
             else:
-                self._verify_statement(statement)
+                verify_iam_policy(statement)
                 self._set_policy(statement, policy_type)
 
     def _set_policy(self, statement: str, policy_type: str = 'IAMPolicy'):
@@ -1384,20 +1365,6 @@ class PolicyMixin:
 
         self.attached_policies[policy_type] = None
 
-    @staticmethod
-    def _verify_statement(statement):
-        """
-        Verifies the policy statement is syntactically correct based on AWS's IAM Policy Grammar.
-        A fake ActionNames and ResourceArns are used to facilitate the simulation of the policy.
-        """
-
-        try:
-            iam.simulate_custom_policy(PolicyInputList=[statement],
-                                       ActionNames=["fake:action"],
-                                       ResourceArns=["arn:aws:iam::123456789012:user/Bob"])
-        except iam.exceptions.InvalidInputException:
-            raise FusilladeHTTPException(status=400, title="Bad Request", detail="Invalid policy format.")
-
     def get_policy_info(self):
         return {'policies': dict([(i, self.get_policy(i)) for i in self.allowed_policy_types if self.get_policy(i)])}
 
@@ -1426,7 +1393,7 @@ class CreateMixin(PolicyMixin):
             pass
         else:
             if statement:
-                cls._verify_statement(statement)
+                verify_iam_policy(statement)
             elif getattr(cls, '_default_policy_path'):
                 statement = get_json_file(cls._default_policy_path)
             ops.extend(new_node.create_policy(statement, run=False, type=new_node.object_type, name=new_node.name))

--- a/fusillade/policy/validator.py
+++ b/fusillade/policy/validator.py
@@ -1,0 +1,21 @@
+"""
+Verifies the policy statement is syntactically correct based on AWS's IAM Policy Grammar.
+A fake ActionNames and ResourceArns are used to facilitate the simulation of the policy.
+
+
+"""
+import json
+
+from dcplib.aws import clients as aws_clients
+from fusillade.errors import FusilladeHTTPException
+
+iam = aws_clients.iam
+
+
+def verify_iam_policy(policy: str):
+    try:
+        iam.simulate_custom_policy(PolicyInputList=[policy],
+                                   ActionNames=["fake:action"],
+                                   ResourceArns=["arn:aws:iam::123456789012:user/Bob"])
+    except iam.exceptions.InvalidInputException:
+        raise FusilladeHTTPException(title="Bad Request", detail="Invalid iam policy format.")

--- a/fusillade/utils/authorize.py
+++ b/fusillade/utils/authorize.py
@@ -245,4 +245,4 @@ def health_checks() -> typing.Dict[str, str]:
     except Exception:
         return dict(iam_health_status='unhealthy')
     else:
-        dict(iam_health_status='ok')
+        return dict(iam_health_status='ok')

--- a/fusillade/utils/authorize.py
+++ b/fusillade/utils/authorize.py
@@ -1,5 +1,7 @@
 import functools
+import json
 import logging
+import typing
 from typing import List, Dict, Optional, Union, Any
 
 from dcplib.aws import clients as aws_clients
@@ -225,3 +227,22 @@ def authorize(actions: List[str],
         return call
 
     return decorate
+
+
+def health_checks() -> typing.Dict[str, str]:
+    try:
+        iam.simulate_custom_policy(
+            PolicyInputList=[json.dumps({
+                "Version": "2012-10-17",
+                "Statement": [{
+                    "Sid": "DefaultRole",
+                    "Effect": "Deny",
+                    "Action": ["fake:action"],
+                    "Resource": "fake:resource"
+                }]})],
+            ActionNames=["fake:action"],
+            ResourceArns=["arn:aws:iam::123456789012:user/Bob"])
+    except Exception:
+        return dict(iam_health_status='unhealthy')
+    else:
+        dict(iam_health_status='ok')


### PR DESCRIPTION
- moving code that uses aws IAM client out of cloud directory.
- creating policy directory for all policy related code.
- creating policy.validator library for function that verify a policies validity.
- moving iam health check to it's own function.

<!--
Please make sure to provide a meaningful title for your PR. 
Do not keep the default title.
-->

<!--
Use GitHub keywords "fixes" or "closes" followed by an issue number if your PR
completely resolves an issue:
"Fixes #123" or "Closes #456"
-->

<!-- 
Describe how you tested this PR, and how you will test the feature after it is
merged. Uncomment below:

### Test plan
-->

<!--
Describe any special instructions to the operator who will deploy your code to
the integration, staging and production deployments. Uncomment below:

### Deployment instructions & migrations
-->

<!-- 
Add notes to highlight the feature when it's released/demoed. Uncomment the
headings below:

### Release notes
-->

<!--
Do you want your PR to be merged by the reviewer using squash or rebase
merging? If so, mention it here.
-->

