### PR TITLE
Implicit Flow Prototype

### DIFF
--- a/example_app/simple_app_flow.py
+++ b/example_app/simple_app_flow.py
@@ -21,7 +21,7 @@ from requests_oauthlib import OAuth2Session
 
 app = Flask(__name__)
 
-port=5001
+port = 5001
 domain = "https://auth.dev.data.humancellatlas.org/"  # Point at your desired domain
 authorization_base_url = f'{domain}/oauth/authorize'
 logout_base_url = f'{domain}/logout'

--- a/example_app/simple_app_flow.py
+++ b/example_app/simple_app_flow.py
@@ -1,0 +1,110 @@
+"""
+This flask application demonstrates a simple application flow, silent authentication, and logout using fusillade.
+This can be used to build single page applications or web applications that require authentication with fusillade.
+
+
+Silent authentication:
+1. Login: visit localhost:{port} to login and retrieve an access token.
+2. Check Session: visit localhost:{port}/checksession to retrieve a new access token.
+3. Logout: visit localhost:{port}/logout to end the sessions
+4. Check Session: visit localhost:{port}/checksession to verify the sessions is close and that a new access token is no
+   retrieved.
+
+"""
+import os
+
+import requests
+from flask import Flask, request, redirect, session, json
+from flask.json import jsonify
+from furl import furl
+from requests_oauthlib import OAuth2Session
+
+app = Flask(__name__)
+
+port=5001
+domain = "https://auth.dev.data.humancellatlas.org/"  # Point at your desired domain
+authorization_base_url = f'{domain}/oauth/authorize'
+logout_base_url = f'{domain}/logout'
+scopes = 'openid email profile'
+
+
+@app.route("/")
+def demo():
+    """Step 1: User Authorization.
+
+    Redirect the user/resource owner to the OAuth provider (i.e. Github)
+    using an URL with a few key OAuth parameters.
+    """
+    github = OAuth2Session(scope=scopes)
+    authorization_url, state = github.authorization_url(authorization_base_url)
+    authorization_url = furl(authorization_url).add(query_params=dict(redirect_uri=f"{request.host_url}callback",
+                                                                      scopes=scopes))
+    # State is used to prevent CSRF, keep this for later.
+    session['oauth_state'] = state
+    return redirect(authorization_url)
+
+
+# Step 2: User authorization, this happens on the provider.
+@app.route("/callback", methods=["GET"])
+def callback():
+    # At this point you can fetch protected resources but lets save
+    # the token and show how this is done from a persisted token
+    # in /profile.
+    assert session['oauth_state'] == request.args['state']
+    session['access_token'] = request.args['access_token']
+    session['username'] = json.loads(request.args['decoded_token'])['email']
+    return jsonify(200)
+
+
+@app.route("/profile", methods=["GET"])
+def profile():
+    """Fetching a protected resource using an OAuth 2 token.
+    """
+    url = furl(f"{domain}/v1/user/{session['username']}").url
+    resp = requests.get(url, headers=get_auth_header()).json()
+    resp['access_token'] = session['access_token']
+    return jsonify(resp)
+
+
+@app.route("/logout", methods=["GET"])
+def logout():
+    """
+    The user is logged out of fusillade
+    :return:
+    """
+    # TODO add logout api to fusillade
+    session.clear()
+    url = furl(logout_base_url, query_params=dict(
+        returnTo='pass'
+    )).url
+    return redirect(url)
+
+
+@app.route("/checksession", methods=["GET"])
+def checksession():
+    """
+    A new access token is retrieved while the user is logged in.
+    https://auth0.com/docs/api-auth/tutorials/silent-authentication
+    :return:
+    """
+    github = OAuth2Session(scope=scopes)
+    authorization_url, state = github.authorization_url(authorization_base_url)
+    authorization_url = furl(authorization_url).add(query_params=dict(redirect_uri=f"{request.host_url}callback",
+                                                                      scopes=scopes,
+                                                                      prompt="none"))
+    # State is used to prevent CSRF, keep this for later.
+    session['oauth_state'] = state
+    return redirect(authorization_url)
+
+
+def get_auth_header(token=None):
+    if not token:
+        token = session['access_token']
+    return {"Authorization": f"Bearer {token}"}
+
+
+if __name__ == "__main__":
+    # This allows us to use a plain HTTP callback
+    os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = "1"
+    app.secret_key = os.urandom(24)
+    app.run(debug=True, port=port)

--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -55,8 +55,8 @@ paths:
     get:
       summary: Logout the user from current sessions with the OIDC provider.
       description: Logout the user from current sessions with the OIDC provider. You can log the users out from a
-      specific application if the you know the client_id for the application. Otherwise the user will be logged out
-      of the default application by oauth2_config.
+       specific application if the you know the client_id for the application. Otherwise the user will be logged out
+       of the default application by oauth2_config.
       operationId: fusillade.api.oauth.logout
       tags:
         - oauth

--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -51,6 +51,25 @@ paths:
           description: OK.
         default:
           description: Unexpected error.
+  /logout:
+    get:
+      summary: Logout the user from current sessions with the OIDC provider.
+      description: Logout the user from current sessions with the OIDC provider. You can log the users out from a
+      specific application if the you know the client_id for the application. Otherwise the user will be logged out
+      of the default application by oauth2_config.
+      operationId: fusillade.api.oauth.logout
+      tags:
+        - oauth
+      parameters:
+        - name: client_id
+          in: query
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK.
+        default:
+          description: Unexpected error.
   /.well-known/openid-configuration:
     get:
       summary: See documentation at

--- a/fusillade/api/oauth.py
+++ b/fusillade/api/oauth.py
@@ -7,8 +7,8 @@ import os
 
 import jwt
 import requests
-from flask import json, request, make_response
 from connexion.lifecycle import ConnexionResponse
+from flask import json, request, make_response
 from furl import furl
 
 from fusillade import Config
@@ -25,7 +25,7 @@ def login():
 def logout():
     oauth2_config = Config.get_oauth2_config()
     openid_provider = Config.get_openid_provider()
-    query_params = getattr(Config.app.current_request,'query_params')
+    query_params = getattr(Config.app.current_request, 'query_params')
     client_id = oauth2_config[openid_provider]["client_id"] if not query_params else query_params.get('client_id')
     url = furl(f"https://{openid_provider}/v2/logout",
                query_params=dict(client_id=client_id)).url
@@ -50,8 +50,7 @@ def authorize():
                            scope="openid email profile",
                            redirect_uri=oauth2_config[openid_provider]["redirect_uri"],
                            state=state,
-                           prompt= query_params.get('prompt') if query_params.get('prompt') == 'none' else 'login' )
-
+                           prompt=query_params.get('prompt') if query_params.get('prompt') == 'none' else 'login')
 
     dest = furl(get_openid_config(openid_provider)["authorization_endpoint"], query_params=auth_params)
     return ConnexionResponse(status_code=requests.codes.found, headers=dict(Location=dest.url))
@@ -149,7 +148,6 @@ def cb():
     openid_config = get_openid_config(openid_provider)
     token_endpoint = openid_config["token_endpoint"]
 
-
     client_id = state.get("client_id")
     client_id = client_id if client_id != 'None' else None
 
@@ -160,7 +158,7 @@ def cb():
         if redirect_uri:
             ConnexionResponse(status_code=requests.codes.unauthorized, headers=dict(Location=redirect_uri))
         else:
-           return {
+            return {
                 "query": query_params,
             }
 

--- a/fusillade/config.py
+++ b/fusillade/config.py
@@ -33,6 +33,8 @@ class Config:
                 sm.get_secret_value(
                     SecretId=f"{os.environ['FUS_SECRETS_STORE']}/"
                     f"{os.environ['FUS_DEPLOYMENT_STAGE']}/oauth2_config")["SecretString"])
+            if 'localhost' in os.getenv('API_DOMAIN_NAME'):
+                cls._oauth2_config[os.getenv('OPENID_PROVIDER')]['redirect_uri'] = f"http://{os.getenv('API_DOMAIN_NAME')}/internal/cb"
         return cls._oauth2_config
 
     @classmethod

--- a/fusillade/config.py
+++ b/fusillade/config.py
@@ -34,7 +34,8 @@ class Config:
                     SecretId=f"{os.environ['FUS_SECRETS_STORE']}/"
                     f"{os.environ['FUS_DEPLOYMENT_STAGE']}/oauth2_config")["SecretString"])
             if 'localhost' in os.getenv('API_DOMAIN_NAME'):
-                cls._oauth2_config[os.getenv('OPENID_PROVIDER')]['redirect_uri'] = f"http://{os.getenv('API_DOMAIN_NAME')}/internal/cb"
+                cls._oauth2_config[os.getenv('OPENID_PROVIDER')]['redirect_uri'] = f"http://" \
+                    f"{os.getenv('API_DOMAIN_NAME')}/internal/cb"
         return cls._oauth2_config
 
     @classmethod

--- a/tests/test_authn_api.py
+++ b/tests/test_authn_api.py
@@ -159,6 +159,9 @@ class TestAuthentication(BaseAPITest, unittest.TestCase):
         resp = self.app.get('/internal/cb')
         self.assertEqual(400, resp.status_code)  # TODO fix
 
+    def test_logout(self):
+        resp = self.app.get('/logout')
+        self.assertEqual(200, resp.status_code)  # TODO fix
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION

Adding logout endpoint 
- The logout endpoint redirect to the auth0 logout endpoint. The client is logged out of a specific service if they include that services client_id.
- Adding an example application to demonstrate how the simple flow works with silent authentication and logout.
- Adding test cases for logout.
- Adding silent authentication when client_id is not provided to Authorization endpoint. The prompt parameter can take 'none' otherwise 'login' is used.
- Adding error response if silent authentication fails.
- When running local test the redirect_uri can be changed to point to the local host.