### PR TITLE
Specifying server for non v1 endpoints

### DIFF
--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -26,6 +26,8 @@ servers:
   - url: https://$API_DOMAIN_NAME/v1
 paths:
   /login:
+    servers:
+    - url: https://$API_DOMAIN_NAME
     get:
       summary: Establish the users identity using the OIDC provider
       description: Send the user agent to an identity provider selector and
@@ -52,6 +54,8 @@ paths:
         default:
           description: Unexpected error.
   /logout:
+    servers:
+      - url: https://$API_DOMAIN_NAME
     get:
       summary: Logout the user from current sessions with the OIDC provider.
       description: Logout the user from current sessions with the OIDC provider. You can log the users out from a
@@ -71,6 +75,8 @@ paths:
         default:
           description: Unexpected error.
   /.well-known/openid-configuration:
+    servers:
+      - url: https://$API_DOMAIN_NAME
     get:
       summary: See documentation at
        [Provider Config](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig)
@@ -91,6 +97,8 @@ paths:
         200:
           description: Returns the supported openid endpoints.
   /.well-known/jwks.json:
+    servers:
+      - url: https://$API_DOMAIN_NAME
     get:
       summary: This endpoint is part of OIDC
       description: Provide the public key used to sign all JWTs minted by the OIDC provider.
@@ -102,6 +110,8 @@ paths:
         200:
           description: Returns the well known jwks.
   /oauth/authorize:
+    servers:
+      - url: https://$API_DOMAIN_NAME
     get:
       summary: See [Auth Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)
       description: This endpoint is part of OIDC and is used to redirect to an openid provider.
@@ -148,6 +158,8 @@ paths:
         default:
           description: Unexpected error.
   /oauth/revoke:
+    servers:
+      - url: https://$API_DOMAIN_NAME
     post:
       summary: Revoke a refresh token
       description: Revokes a refresh token from a client making all future token refresh requests fail.
@@ -174,6 +186,8 @@ paths:
         default:
           description: Unexpected error.
   /oauth/token:
+    servers:
+      - url: https://$API_DOMAIN_NAME
     post:
       summary: Retrieve the authentications token
       description: This endpoint is part of OIDC and is used to redirect to an openid provider.
@@ -223,6 +237,8 @@ paths:
         default:
           description: Unexpected error.
   /oauth/userinfo:
+    servers:
+      - url: https://$API_DOMAIN_NAME
     get:
       summary: See [User Info](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo)
       description: This endpoint is part of OIDC and is used to redirect to an openid provider.
@@ -252,6 +268,8 @@ paths:
         401:
           $ref: '#/components/responses/401'
   /echo:
+    servers:
+      - url: https://$API_DOMAIN_NAME
     get:
       summary: echoes the response
       description: Echoes the response back.


### PR DESCRIPTION
This should reduce the amount of fusillade test refactoring to 0. However we may need to modify the HCA CLI to handle the `server` parameter in openapi `paths`.