### PR TITLE
Adding simple API key support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -85,6 +85,17 @@ The OIDC provide handle the OIDC authentication process. [Auth0](https://auth0.c
 1. Set **oauth2_config** in AWS Secrets Manager using `make set_oauth2_config`. **oauth2_config** contains the fields 
 needed to proxy an OIDC provider. Populate this file with the OIDC providers you'd like to use to authenticate users. 
 See [oauth2_config.json](../master/deployment/example/oauth2_config.example.json) for the expected format.
+
+### Fusillade API key for OIDC provider
+You can generate API keys to provide fusillade access to your OIDC provider. This can be helpful if you want to 
+adding information from fusillade into the tokens signed by the OIDC provider.
+
+#### Generate an API Key
+1. Run `$ ./scripts/generate_api_key.py --owner {user email}`
+1. record the API key presented in the console.
+
+Owner will be used to determine the access privilages for the API. You must have permissions to create and modify
+secrets in the AWS project fusillade is running on to use this script.
   
 ## Set Secrets
 

--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -442,6 +442,7 @@ paths:
       operationId: fusillade.api.users.get_users_groups
       security:
         - BearerAuth: []
+        - ApiKeyAuth: []
       parameters:
         - $ref: '#/components/parameters/user_id'
         - $ref: '#/components/parameters/next_token'
@@ -467,6 +468,7 @@ paths:
       operationId: fusillade.api.users.put_users_groups
       security:
         - BearerAuth: []
+        - ApiKeyAuth: []
       parameters:
         - $ref: '#/components/parameters/user_id'
         - $ref: '#/components/parameters/action'
@@ -498,6 +500,7 @@ paths:
       operationId: fusillade.api.users.get_users_roles
       security:
         - BearerAuth: []
+        - ApiKeyAuth: []
       parameters:
         - $ref: '#/components/parameters/user_id'
         - $ref: '#/components/parameters/next_token'
@@ -932,6 +935,21 @@ paths:
           description: Unexpected error.
       tags:
         - role
+  /test:
+    get:
+      summary: For testing authentication methods
+      description: Used for easily testing different securitySchemas easily
+      operationId: fusillade.api.internal.test
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      responses:
+        200:
+          description: Policy modified.
+        401:
+          $ref: '#/components/responses/401'
+        default:
+          description: Unexpected error.
 components:
   parameters:
     user_id:
@@ -1080,3 +1098,8 @@ components:
         scheme: bearer
         bearerFormat: JWT
         x-bearerInfoFunc: fusillade.utils.security.verify_jwt
+      ApiKeyAuth:
+        type: apiKey
+        in: header
+        name: X-API-KEY
+        x-apikeyInfoFunc: fusillade.utils.api_key.verify_api_key

--- a/fusillade/api/internal.py
+++ b/fusillade/api/internal.py
@@ -53,3 +53,7 @@ def get_openip_health_status() -> dict:
 
 def echo():
     return str(request.__dict__)
+
+
+def test():
+    return ConnexionResponse(status_code=200)

--- a/fusillade/utils/api_key.py
+++ b/fusillade/utils/api_key.py
@@ -14,10 +14,13 @@ from fusillade.errors import FusilladeHTTPException
 
 logger = logging.getLogger(__name__)
 
+# TODO if the api_key is not found, retrieve the secret and try again.
 api_keys = AwsSecret('/'.join([os.environ['FUS_SECRETS_STORE'],
                                os.environ['FUS_DEPLOYMENT_STAGE'],
                                'api_keys']))
-
+# TODO store the API keys in cloud directory and associate then with a specific user. Create an front end API so user
+#  can manage their own api tokens.
+# TODO track when an api token is used.
 
 def hash(key: bytearray) -> bytearray:
     digest = Hash(SHA256(), backend=default_backend())

--- a/fusillade/utils/api_key.py
+++ b/fusillade/utils/api_key.py
@@ -4,6 +4,7 @@ Sets the Auth0 API key in AWS secrets manager
 import json
 import logging
 import os
+import typing
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.hashes import SHA256, Hash
@@ -24,7 +25,7 @@ def hash(key: bytearray) -> bytearray:
     return digest.finalize().hex()
 
 
-def generate_api_key():
+def generate_api_key(owner: str) -> typing.Tuple[str, dict]:
     from os import urandom
 
     # Generate key
@@ -35,6 +36,7 @@ def generate_api_key():
         prefix: {
             "description": "API key used to by Auth0 to access Fusillade.",
             "hash": digest,
+            "owner": owner
         }
     }
 

--- a/fusillade/utils/api_key.py
+++ b/fusillade/utils/api_key.py
@@ -1,0 +1,54 @@
+"""
+Sets the Auth0 API key in AWS secrets manager
+"""
+import json
+import logging
+import os
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.hashes import SHA256, Hash
+
+from dcplib.aws_secret import AwsSecret
+from fusillade.errors import FusilladeHTTPException
+
+logger = logging.getLogger(__name__)
+
+api_keys = AwsSecret('/'.join([os.environ['FUS_SECRETS_STORE'],
+                               os.environ['FUS_DEPLOYMENT_STAGE'],
+                               'api_keys']))
+
+
+def hash(key: bytearray) -> bytearray:
+    digest = Hash(SHA256(), backend=default_backend())
+    digest.update(key)
+    return digest.finalize().hex()
+
+
+def generate_api_key():
+    from os import urandom
+
+    # Generate key
+    key = urandom(32)
+    digest = hash(key)
+    prefix = key.hex()[:7]  # grab first 7 characters
+    return key.hex(), {
+        prefix: {
+            "description": "API key used to by Auth0 to access Fusillade.",
+            "hash": digest,
+        }
+    }
+
+
+def verify_api_key(key: str):
+    try:
+        expected = json.loads(api_keys.value)[key[:7]]['hash']
+    except RuntimeError as ex:
+        logger.debug({"message": "Failed to validate token. Secret does not exist."}, exc_info=True)
+        raise FusilladeHTTPException(401, 'Unauthorized', 'Authorization token is invalid') from ex
+    except KeyError as ex:
+        logger.debug({"message": "Failed to validate token. Key does not exist."}, exc_info=True)
+        raise FusilladeHTTPException(401, 'Unauthorized', 'Authorization token is invalid') from ex
+    else:
+        if expected != bytearray.fromhex(key):
+            logger.debug({"message": "Failed to validate token. Invalid API key"}, exc_info=True)
+            raise FusilladeHTTPException(401, 'Unauthorized', 'Authorization token is invalid')

--- a/fusillade/utils/security.py
+++ b/fusillade/utils/security.py
@@ -139,4 +139,8 @@ def verify_jwt(token: str) -> typing.Optional[typing.Mapping]:
     except jwt.PyJWTError as ex:  # type: ignore
         logger.debug({"message": "Failed to validate token."}, exc_info=True)
         raise FusilladeHTTPException(401, 'Unauthorized', 'Authorization token is invalid') from ex
-    return verified_tok
+    tokeninfo_endpoint = [i for i in verified_tok['aud'] if i.endswith('userinfo') or i.endswith('tokeninfo')]
+    if tokeninfo_endpoint:
+        return requests.get(tokeninfo_endpoint[0], headers={'Authorization': f"Bearer {token}"}).json()
+    else:
+        return verified_tok

--- a/fusillade/utils/security.py
+++ b/fusillade/utils/security.py
@@ -141,6 +141,9 @@ def verify_jwt(token: str) -> typing.Optional[typing.Mapping]:
         raise FusilladeHTTPException(401, 'Unauthorized', 'Authorization token is invalid') from ex
     tokeninfo_endpoint = [i for i in verified_tok['aud'] if i.endswith('userinfo') or i.endswith('tokeninfo')]
     if tokeninfo_endpoint:
+        # Use the OIDC tokeninfo endpoint to get info about the user.
         return requests.get(tokeninfo_endpoint[0], headers={'Authorization': f"Bearer {token}"}).json()
     else:
+        # If No OIDC tokeninfo endpoint is present then this is a google service account and there is no info to
+        # retrieve
         return verified_tok

--- a/scripts/generate_api_key.py
+++ b/scripts/generate_api_key.py
@@ -7,12 +7,18 @@ import json
 import os
 import sys
 
+import argparse
+
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
 from fusillade.utils.api_key import generate_api_key, api_keys
 
-key, secret = generate_api_key()
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--owner", required=True)
+args = parser.parse_args()
+
+key, secret = generate_api_key(args.owner)
 print(f"This value will only be visible once. Record it now. API KEY: '{key}'")
 print(secret)
 

--- a/scripts/generate_api_key.py
+++ b/scripts/generate_api_key.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+"""
+Sets the Auth0 API key in AWS secrets manager
+"""
+import json
+import os
+import sys
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from fusillade.utils.api_key import generate_api_key, api_keys
+
+key, secret = generate_api_key()
+print(f"This value will only be visible once. Record it now. API KEY: '{key}'")
+print(secret)
+
+try:
+    keys = json.loads(api_keys.value)
+except RuntimeError:
+    print(f"Creating AWS Secret {api_keys.name}.")
+    keys = {}
+print(f"Updating AWS Secret {api_keys.name}.")
+keys.update(secret)
+api_keys.update(json.dumps(keys))

--- a/tests/test_authn_api.py
+++ b/tests/test_authn_api.py
@@ -161,8 +161,10 @@ class TestAuthentication(BaseAPITest, unittest.TestCase):
         resp = self.app.get('/logout')
         self.assertEqual(200, resp.status_code)
 
+    @unittest.skipIf(os.environ['FUS_DEPLOYMENT_STAGE'] != 'dev',
+                     f"No TEST API Key generated for os.environ['FUS_DEPLOYMENT_STAGE']")
     def test_api_key(self):
-        resp = self.app.get('/test', headers={'X-API-KEY': '60c1a63c33b56976a35b4a5f46fdc50220b94c5b2033ca7ff4d57e622b1de887'})
+        resp = self.app.get('/test', headers={'X-API-KEY': 'b1eec29e9789a7174afee76ea8a35c04d302ecd4e9be2a4cd12848fcaa51c292'})
         self.assertEqual(200, resp.status_code)
 
 if __name__ == '__main__':

--- a/tests/test_authn_api.py
+++ b/tests/test_authn_api.py
@@ -159,7 +159,11 @@ class TestAuthentication(BaseAPITest, unittest.TestCase):
 
     def test_logout(self):
         resp = self.app.get('/logout')
-        self.assertEqual(200, resp.status_code)  # TODO fix
+        self.assertEqual(200, resp.status_code)
+
+    def test_api_key(self):
+        resp = self.app.get('/test', headers={'X-API-KEY': '60c1a63c33b56976a35b4a5f46fdc50220b94c5b2033ca7ff4d57e622b1de887'})
+        self.assertEqual(200, resp.status_code)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Admins can generate API keys for them self to be used in other application. The primary use case is to allow auth0 to make API call to fusillade to enhance the token returned by auth0's userinfo endpoint. In the future this can be built upon to support api tokens for individual users.

A testing endpoint was added to simplify the testing of authentication without worrying about the response.