### PR TITLE
Adding group, and role info from fusillade to userinfo

### DIFF
--- a/fusillade/api/oauth.py
+++ b/fusillade/api/oauth.py
@@ -121,10 +121,16 @@ def userinfo(token_info):
     """
     Part of OIDC
     """
-    openid_provider = Config.get_openid_provider()
-    openid_config = get_openid_config(openid_provider)
-    return ConnexionResponse(status_code=requests.codes.found,
-                             headers=dict(Location=openid_config["userinfo_endpoint"]))
+    from fusillade.clouddirectory import User, Group, Role
+    user = User(token_info['email'])
+    # TODO save user info in fusillade at the same time.
+    token_info[f"https://{os.environ['API_DOMAIN_NAME']}/app_metadata"] = {
+        'authorization': {
+            'groups': Group.get_names(user.groups),
+            'roles': Role.get_names(user.roles)
+        }
+    }
+    return ConnexionResponse(status_code=requests.codes.ok, body=token_info)
 
 
 def get_userinfo(token_info):

--- a/fusillade/api/oauth.py
+++ b/fusillade/api/oauth.py
@@ -127,7 +127,8 @@ def userinfo(token_info):
     token_info[f"https://{os.environ['API_DOMAIN_NAME']}/app_metadata"] = {
         'authorization': {
             'groups': Group.get_names(user.groups),
-            'roles': Role.get_names(user.roles)
+            'roles': Role.get_names(user.roles),
+            'actions': User.get_actions()
         }
     }
     return ConnexionResponse(status_code=requests.codes.ok, body=token_info)

--- a/fusillade/api/oauth.py
+++ b/fusillade/api/oauth.py
@@ -128,7 +128,7 @@ def userinfo(token_info):
         'authorization': {
             'groups': Group.get_names(user.groups),
             'roles': Role.get_names(user.roles),
-            'actions': User.get_actions()
+            'scope': User.get_actions()
         }
     }
     return ConnexionResponse(status_code=requests.codes.ok, body=token_info)

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -1674,7 +1674,7 @@ class User(CloudNode, RolesMixin, CreateMixin, OwnershipMixin):
         statements = list(itertools.chain.from_iterable(
             [json.loads(p['policy'])['Statement'] for p in self.get_authz_params()['policies']]))
         actions = list(itertools.chain.from_iterable([s['Action'] for s in statements if s['Effect'] == 'Allow']))
-        
+
         # Need to handle cases where the actions has a wildcard. All actions that match the wildcard are removed and
         # only the wildcard value will remain.
         prefixes = []

--- a/fusillade/errors.py
+++ b/fusillade/errors.py
@@ -52,3 +52,11 @@ class FusilladeForbiddenException(FusilladeHTTPException):
                          title="Forbidden",
                          detail=detail,
                          *args, **kwargs)
+
+class FusilladeTooManyRequestsException(FusilladeHTTPException):
+    def __init__(self, detail: str = "Rate limit reached. Try again in 30 seconds.",
+                 *args, **kwargs) -> None:
+        super().__init__(status=requests.codes.forbidden,
+                         title="Too Many Requests",
+                         detail=detail,
+                         *args, **kwargs)

--- a/fusillade/utils/security.py
+++ b/fusillade/utils/security.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 from fusillade import Config
-from fusillade.errors import FusilladeHTTPException
+from fusillade.errors import FusilladeHTTPException, FusilladeTooManyRequestsException
 
 logger = logging.getLogger(__name__)
 

--- a/fusillade/utils/security.py
+++ b/fusillade/utils/security.py
@@ -12,7 +12,6 @@ import requests
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
 
-from chalicelib.fusillade.errors import FusilladeTooManyRequestsException
 from fusillade import Config
 from fusillade.errors import FusilladeHTTPException
 


### PR DESCRIPTION
This PR adds additional authorization info from fusillade to the userinfo return from the OIDC provider. A response from the /oauth/userinfo endpoint will include these additional fields:
```json
{
  "https://auth.data.humancellatlas.org/app_metadata": {
    "authorization": {
      "groups": [
        "user_default"
      ],
      "roles": [
        "fusillade_admin"
      ]
    }
  }
}
```

The groups and roles fields correspond to the ones the users is associated with.

### Rate Limits
The OIDC provided enforces [rate limits](https://auth0.com/docs/policies/rate-limits) on this endpoint so the userinfo is cached in the lambda to prevent rate limiting by the provider. In the future userinfo should be cached somewhere all lambdas can access. An error message indicating a rate limit has been reached by the provider is returned, if a rate limit is reached.

### Summary
- Adding error too many redirects
- adding function to resolve the object references of groups and roles to a user friendly name.
- adding authorization claims to userinfo.

@aaclan-ebi this reverses change previously made in #293, but should not affect cause any conflict.