### PR TITLE
[PRIORITY] fixing redirect issue

### DIFF
--- a/fusillade/utils/security.py
+++ b/fusillade/utils/security.py
@@ -25,19 +25,17 @@ gserviceaccount_domain = "iam.gserviceaccount.com"
 session = requests.Session()
 
 
-@functools.lru_cache(maxsize=32)
-def get_openid_config(openid_provider=None) -> dict:
+# Had to remove the LRU from this function because it was cause error with too many redirects.
+def get_openid_config(openid_provider: str) -> dict:
     """
 
     :param openid_provider: the openid provider's domain.
     :return: the openid configuration
     """
-    if not openid_provider:
-        openid_provider = Config.get_openid_provider()
-    elif openid_provider.endswith(gserviceaccount_domain):
+    if openid_provider.endswith(gserviceaccount_domain):
         openid_provider = 'accounts.google.com'
-    elif openid_provider.startswith("https://"):
-        openid_provider = furl(openid_provider).host
+    else:
+        openid_provider = Config.get_openid_provider()
     res = requests.get(f"https://{openid_provider}/.well-known/openid-configuration")
     res.raise_for_status()
     return res.json()

--- a/fusillade/utils/security.py
+++ b/fusillade/utils/security.py
@@ -2,16 +2,15 @@
 """
 Used by connexion to verify the JWT in Authorization header of the request.
 """
-import functools, base64, typing
-
-import requests
-import jwt
+import base64
+import functools
 import logging
+import typing
 
-from cryptography.hazmat.primitives.asymmetric import rsa
+import jwt
+import requests
 from cryptography.hazmat.backends import default_backend
-
-from furl import furl
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from fusillade import Config
 from fusillade.errors import FusilladeHTTPException
@@ -25,7 +24,6 @@ gserviceaccount_domain = "iam.gserviceaccount.com"
 session = requests.Session()
 
 
-# Had to remove the LRU from this function because it was cause error with too many redirects.
 def get_openid_config(openid_provider: str) -> dict:
     """
 

--- a/tests/test_authn_api.py
+++ b/tests/test_authn_api.py
@@ -41,7 +41,7 @@ class TestAuthentication(BaseAPITest, unittest.TestCase):
         scopes_combination = [["openid", "email", "profile", "offline"], ["openid", "email", "profile", "offline"]]
         tests = product(states, scopes_combination)
         OPENID_PROVIDER = os.environ["OPENID_PROVIDER"]
-        redirect_url_host = [OPENID_PROVIDER, os.environ["API_DOMAIN_NAME"]]
+        redirect_url_host = [OPENID_PROVIDER]
         query_params_client_id = {
             "response_type": "code",
             "redirect_uri": REDIRECT_URI,


### PR DESCRIPTION
fixes #282

- The error was cause by providing an incorrect openid provider value
- Had to remove the LRU caching from this function because it was also causing too many redirects errors.