### PR TITLE
Redirect fix

### DIFF
--- a/fusillade/api/oauth.py
+++ b/fusillade/api/oauth.py
@@ -87,7 +87,7 @@ def serve_openid_config():
             title="Bad Request",
             detail=f"host: {auth_host}, is not supported. host must be {os.environ['API_DOMAIN_NAME']}.")
     openid_config = get_openid_config(Config.get_openid_provider()).copy()
-    openid_config.update(**proxied_endpoints) 
+    openid_config.update(**proxied_endpoints)
     return ConnexionResponse(body=openid_config, status_code=requests.codes.ok)
 
 

--- a/fusillade/api/oauth.py
+++ b/fusillade/api/oauth.py
@@ -80,14 +80,14 @@ def serve_openid_config():
     """
     Part of OIDC
     """
-    openid_config = get_openid_config(Config.get_openid_provider())
     auth_host = request.headers['host']
     if auth_host != os.environ["API_DOMAIN_NAME"]:
         raise FusilladeHTTPException(
             status=400,
             title="Bad Request",
             detail=f"host: {auth_host}, is not supported. host must be {os.environ['API_DOMAIN_NAME']}.")
-    openid_config.update(**proxied_endpoints)
+    openid_config = get_openid_config(Config.get_openid_provider()).copy()
+    openid_config.update(**proxied_endpoints) 
     return ConnexionResponse(body=openid_config, status_code=requests.codes.ok)
 
 

--- a/fusillade/utils/security.py
+++ b/fusillade/utils/security.py
@@ -26,23 +26,20 @@ session = requests.Session()
 openid_config = dict()
 
 
+@functools.lru_cache(maxsize=32)
 def get_openid_config(openid_provider: str) -> dict:
     """
 
     :param openid_provider: the openid provider's domain.
     :return: the openid configuration
     """
-    if openid_provider not in openid_config:
-        if openid_provider.endswith(gserviceaccount_domain):
-            openid_provider = 'accounts.google.com'
-        else:
-            openid_provider = Config.get_openid_provider()
-        res = requests.get(f"https://{openid_provider}/.well-known/openid-configuration")
-        res.raise_for_status()
-        openid_config[openid_provider] = res.json()
-        logger.info({'message': "caching missed", 'openid_provider': {openid_provider: openid_config[openid_provider]}})
+    if openid_provider.endswith(gserviceaccount_domain):
+        openid_provider = 'accounts.google.com'
     else:
-        logger.info({'message': "caching hit", 'openid_provider': {openid_provider: openid_config[openid_provider]}})
+        openid_provider = Config.get_openid_provider()
+    res = requests.get(f"https://{openid_provider}/.well-known/openid-configuration")
+    res.raise_for_status()
+    openid_config[openid_provider] = res.json()
     return openid_config[openid_provider]
 
 

--- a/fusillade/utils/security.py
+++ b/fusillade/utils/security.py
@@ -25,6 +25,7 @@ session = requests.Session()
 
 openid_config = dict()
 
+
 def get_openid_config(openid_provider: str) -> dict:
     """
 
@@ -39,7 +40,9 @@ def get_openid_config(openid_provider: str) -> dict:
         res = requests.get(f"https://{openid_provider}/.well-known/openid-configuration")
         res.raise_for_status()
         openid_config[openid_provider] = res.json()
-        logger.info({'message': "caching", 'openid_provider': {openid_provider: openid_config[openid_provider]}})
+        logger.info({'message': "caching missed", 'openid_provider': {openid_provider: openid_config[openid_provider]}})
+    else:
+        logger.info({'message': "caching hit", 'openid_provider': {openid_provider: openid_config[openid_provider]}})
     return openid_config[openid_provider]
 
 


### PR DESCRIPTION
Fixed #282

The problem is how we were modified the cached value directly in serve_openid_config. This was overwriting the correct value. This result in an infinite loop. We are now modifying a copy of the value.

- copy dict, don't modify directly
- Using LRU cache again 
