### PR TITLE
[easy] Prepare for resource ACL

### DIFF
--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -13,7 +13,7 @@ import os
 from collections import namedtuple, defaultdict
 from datetime import datetime
 from enum import Enum, auto
-from typing import Iterator, Any, Tuple, Dict, List, Callable, Optional, Union, Type
+from typing import Iterator, Any, Tuple, Dict, List, Callable, Optional, Union, Type, Set
 
 import itertools
 


### PR DESCRIPTION
- modified CloudDirectory.create_folder to allow a creator to be passed in, with 'fusillade' as default name.
- adding CloudNode.from_name to make it easier to generate different types of CloudNodes. This will be used to support resource ACL.
- removed unused functions from CloudDirectory

<!--
Please make sure to provide a meaningful title for your PR. 
Do not keep the default title.
-->

<!--
Use GitHub keywords "fixes" or "closes" followed by an issue number if your PR
completely resolves an issue:
"Fixes #123" or "Closes #456"
-->

<!-- 
Describe how you tested this PR, and how you will test the feature after it is
merged. Uncomment below:

### Test plan
-->

<!--
Describe any special instructions to the operator who will deploy your code to
the integration, staging and production deployments. Uncomment below:

### Deployment instructions & migrations
-->

<!-- 
Add notes to highlight the feature when it's released/demoed. Uncomment the
headings below:

### Release notes
-->

<!--
Do you want your PR to be merged by the reviewer using squash or rebase
merging? If so, mention it here.
-->

