### PR TITLE
[Parts 3] Supporting ResourceTypes and ResourceIds

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,7 +57,7 @@ See https://github.com/HumanCellAtlas/fusillade/issues/307 for current progress.
 
 ## Cloud Directory Structure
 
-![Cloud Directory Structure](https://www.lucidchart.com/publicSegments/view/3f6f3cdc-7429-460c-b45f-33ae35d9e07c/image.png)
+![Cloud Directory Structure](https://www.lucidchart.com/publicSegments/view/b08deb5a-881c-4eec-94af-9917f82d285f/image.png)
 
 # Installing and configuring Fusillade
 

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -909,7 +909,12 @@ class CloudDirectory:
     @staticmethod
     def get_obj_type_path(obj_type: str) -> str:
         obj_type = obj_type.lower()
-        return obj_type_path[obj_type]
+        try:
+            return obj_type_path[obj_type]
+        except KeyError:
+            if obj_type.startswith('resource'):
+                # check that it's a resource type with format resource/resource_type
+                return f'/{obj_type}/id/'
 
     def lookup_policy(self, object_id: str) -> List[Dict[str, Any]]:
         # retrieve all of the policies attached to an object and its parents.
@@ -1867,6 +1872,7 @@ class Group(Principal):
         :param name:
         """
         super(Group, self).__init__(name=name, object_ref=object_ref)
+        self._groups: Optional[List[str]] = None
         self._roles: Optional[List[str]] = None
 
     def get_users_iter(self) -> Tuple[Dict[str, Union[list, Any]], Any]:

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -1872,7 +1872,6 @@ class Group(Principal):
         :param name:
         """
         super(Group, self).__init__(name=name, object_ref=object_ref)
-        self._groups: Optional[List[str]] = None
         self._roles: Optional[List[str]] = None
 
     def get_users_iter(self) -> Tuple[Dict[str, Union[list, Any]], Any]:

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -467,6 +467,7 @@ class CloudDirectory:
         info https://docs.aws.amazon.com/clouddirectory/latest/developerguide/key_concepts_directory.html
         """
         attributes = self.get_object_attribute_list(facet='IAMPolicy', **kwargs)
+        statement.update(Version="2012-10-17")
         attributes.extend([
             dict(
                 Key=dict(

--- a/fusillade/directory_schema.json
+++ b/fusillade/directory_schema.json
@@ -136,6 +136,40 @@
         "member_of"
       ]
     },
+    "access_link": {
+      "facetAttributes": {
+        "access_level": {
+          "attributeDefinition": {
+            "attributeType": "STRING",
+            "isImmutable": false,
+            "attributeRules": {}
+          },
+          "requiredBehavior": "REQUIRED_ALWAYS"
+        },
+        "resource": {
+          "attributeDefinition": {
+            "attributeType": "STRING",
+            "isImmutable": true,
+            "attributeRules": {
+            }
+          },
+          "requiredBehavior": "REQUIRED_ALWAYS"
+        },
+        "principal": {
+          "attributeDefinition": {
+            "attributeType": "STRING",
+            "isImmutable": true,
+            "attributeRules": {}
+          },
+          "requiredBehavior": "REQUIRED_ALWAYS"
+        }
+      },
+      "identityAttributeOrder": [
+        "principal",
+        "resource",
+        "access_level"
+      ]
+    },
     "ownership_link": {
       "facetAttributes": {
         "owner_of": {

--- a/fusillade/directory_schema.json
+++ b/fusillade/directory_schema.json
@@ -166,8 +166,7 @@
       },
       "identityAttributeOrder": [
         "principal",
-        "resource",
-        "access_level"
+        "resource"
       ]
     },
     "ownership_link": {

--- a/fusillade/policy/validator.py
+++ b/fusillade/policy/validator.py
@@ -21,8 +21,26 @@ def verify_iam_policy(policy: str):
         raise FusilladeHTTPException(title="Bad Request", detail="Invalid iam policy format.")
 
 
+def verify_resource_policy(policy: str):
+    try:
+        iam.simulate_custom_policy(
+            PolicyInputList=[json.dumps({"Version": "2012-10-17",
+                                         "Statement": [{
+                                             "Effect": "Allow",
+                                             "Action": ["fake:Fake"],
+                                             "Resource": "arn:hca:fus:*:*:resource/fake/1234",
+                                         }]}), ],
+            ActionNames=["fake:action"],
+            ResourceArns=["arn:aws:iam::123456789012:user/Bob"],
+            ResourcePolicy=policy,
+            CallerArn='arn:aws:iam::634134578715:user/anyone')
+    except iam.exceptions.InvalidInputException:
+        raise FusilladeHTTPException(title="Bad Request", detail="Invalid resource policy format.")
+
+
 _policy_func = {
     "IAMPolicy": verify_iam_policy,
+    "ResourcePolicy": verify_resource_policy
 }
 
 

--- a/fusillade/resource.py
+++ b/fusillade/resource.py
@@ -164,7 +164,7 @@ class ResourceType(CloudNode):
                                             ' '.join(_actions),
                                             UpdateActions.CREATE_OR_UPDATE,
                                         )])
-        # TODO this actions from all policies
+        # TODO remove this actions from all access policies
         self._actions = None
 
     def check_actions(self, policy: dict):
@@ -390,7 +390,7 @@ class ResourceId(CloudNode):
 
     def add_principals(self, principals: List[Type['Principal']], access_level):
         """
-        add a typed linked from resource to principal with the access type.
+        add a typed link from resource to principal with the access type.
         verifies that the policy exists before making link
 
         :param principal_type:

--- a/fusillade/resource.py
+++ b/fusillade/resource.py
@@ -330,6 +330,12 @@ class ResourceType(CloudNode):
         except cd_client.exceptions.ResourceNotFoundException:
             raise FusilladeNotFoundException(f"Failed to delete {self.name}. {self.object_type} does not exist.")
 
+    def create_id(self, name: str, owner: str = None, **kwargs) -> 'ResourceId':
+        return ResourceId.create(self, name, owner, **kwargs)
+
+    def get_id(self, *args, **kwargs) -> 'ResourceId':
+        return ResourceId(self, *args, **kwargs)
+
 
 class ResourceId(CloudNode):
     """arn:*:resource/{resource_type}/{resource_id}"""
@@ -337,8 +343,8 @@ class ResourceId(CloudNode):
     _facet: str = 'NodeFacet'
     allowed_policy_types = ['Resource']
 
-    def __init__(self, resource_type, *args, **kwargs):
-        self.resource_type: ResourceType = ResourceType(resource_type)
+    def __init__(self, resource_type: ResourceType, *args, **kwargs):
+        self.resource_type: ResourceType = resource_type
         super(ResourceId, self).__init__(*args, **kwargs)
         self._principals = None  # update roles
 
@@ -356,7 +362,7 @@ class ResourceId(CloudNode):
         return name
 
     @classmethod
-    def create(cls, resource_type: str, name: str, owner: str = None, **kwargs) -> 'ResourceId':
+    def create(cls, resource_type: ResourceType, name: str, owner: str = None, **kwargs) -> 'ResourceId':
         ops = []
         new_node = cls(resource_type, name=name)
         _owner = owner if owner else "fusillade"

--- a/fusillade/resource.py
+++ b/fusillade/resource.py
@@ -13,13 +13,14 @@ actions is removed from the resource type all existing access policies with this
 The owner policy is added to the resource type and is used to determine what actions the owner of a resource Id can
 perform on a resource.
 """
-
 import json
 import os
-from typing import List, Dict, Any, Union
+from collections import defaultdict
+from typing import List, Dict, Any, Type
 
-from fusillade.clouddirectory import CloudNode, cd_client, ConsistencyLevel, logger
-from fusillade.errors import FusilladeHTTPException, FusilladeBadRequestException
+from fusillade.clouddirectory import CloudNode, cd_client, ConsistencyLevel, logger, \
+    UpdateObjectParams, ValueTypes, UpdateActions, User
+from fusillade.errors import FusilladeHTTPException, FusilladeNotFoundException, FusilladeBadRequestException
 from fusillade.policy.validator import verify_iam_policy
 
 proj_path = os.path.dirname(__file__)
@@ -140,6 +141,16 @@ class ResourceType(CloudNode):
             self._actions = self._actions.split(' ')
         return self._actions
 
+    def add_actions(self):
+        set(self._actions)
+
+    def check_actions(self, policy: dict):
+        policy_actions = set()
+        for s in policy['Statement']:
+            policy_actions.update(s['Action'])
+        if not policy_actions.issubset(set(self.actions)):
+            raise FusilladeBadRequestException(detail="Invalid actions in policy.")
+
     @staticmethod
     def hash_name(name):
         """
@@ -152,6 +163,18 @@ class ResourceType(CloudNode):
     def list_policies(self, per_page=None, next=None):
         children, next_token = self.cd.list_object_children_paged(f"{self.object_ref}/policy", next, per_page)
         return [f"/resource/{self.name}/policy/{child}" for child in children.keys()], next_token
+
+    def list_ids(self, per_page=None, next=None):
+        children, next_token = self.cd.list_object_children_paged(f"{self.object_ref}/id", next, per_page)
+        return [f"/resource/{self.name}/id/{child}" for child in children.keys()], next_token
+
+    def get_policy_reference(self, policy_name: str) -> str:
+        """Returns a policy reference that can be used by cloud directory"""
+        return f"{self.object_ref}/policy/{policy_name}"
+
+    def get_policy_path(self, policy_name: str):
+        """Returns a human readable policy path"""
+        return f"/resource/{self.name}/policy/{policy_name}"
 
     @staticmethod
     def format_policy(policy: dict) -> str:
@@ -219,3 +242,175 @@ class ResourceType(CloudNode):
                              ))
         else:
             return operations
+
+    def delete_policy(self, policy_name):
+        try:
+            self.cd.delete_object(self.get_policy_reference(policy_name))
+        except cd_client.exceptions.ResourceNotFoundException:
+            raise FusilladeNotFoundException(f"{self.get_policy_path(policy_name)} does not exist.")
+
+    def update_policy(self, policy_name: str, policy: dict):
+        self.check_actions(policy)
+        policy = self.format_policy(policy)
+        params = [
+            UpdateObjectParams('POLICY',
+                               'policy_document',
+                               ValueTypes.BinaryValue,
+                               policy,
+                               UpdateActions.CREATE_OR_UPDATE,
+                               )
+        ]
+        try:
+            verify_iam_policy(policy)
+            self.cd.update_object_attribute(self.get_policy_reference(policy_name),
+                                            params,
+                                            self.cd.node_schema)
+        except cd_client.exceptions.LimitExceededException as ex:
+            raise FusilladeHTTPException(ex)
+        except cd_client.exceptions.ResourceNotFoundException:
+            raise FusilladeNotFoundException(f"{self.get_policy_path(policy_name)} does not exist.")
+        else:
+            logger.info(dict(message="Policy updated",
+                             object=dict(
+                                 type=self.object_type,
+                                 path_name=self._path_name
+                             ),
+                             policy=dict(
+                                 link_name=policy_name,
+                                 policy_type=self.policy_type)
+                             ))
+
+    def get_policy(self, policy_name):
+        try:
+            resp = self.cd.get_object_attributes(
+                self.get_policy_reference(policy_name),
+                'POLICY',
+                ['policy_document', 'policy_type'],
+                self.cd.node_schema
+            )
+            attrs = dict([(attr['Key']['Name'], attr['Value'].popitem()[1]) for attr in resp['Attributes']])
+        except cd_client.exceptions.ResourceNotFoundException:
+            raise FusilladeNotFoundException(f"{self.get_policy_path(policy_name)} does not exist.")
+        return attrs
+
+    def policy_exists(self, policy_name: str):
+        try:
+            self.cd.get_object_info(self.get_policy_reference(policy_name))
+        except cd_client.exceptions.ResourceNotFoundException:
+            raise FusilladeBadRequestException(f"{self.object_type}/{self.name}/policy/{policy_name} does not exist.")
+
+    def delete_node(self):
+        try:
+            self.cd.delete_object(self.object_ref, traverse=True)
+        except cd_client.exceptions.ResourceNotFoundException:
+            raise FusilladeNotFoundException(f"Failed to delete {self.name}. {self.object_type} does not exist.")
+
+
+class ResourceId(CloudNode):
+    """arn:*:resource/{resource_type}/{resource_id}"""
+
+    _facet: str = 'NodeFacet'
+    allowed_policy_types = ['Resource']
+
+    def __init__(self, resource_type, *args, **kwargs):
+        self.resource_type: ResourceType = ResourceType(resource_type)
+        super(ResourceId, self).__init__(*args, **kwargs)
+        self._principals = None  # update roles
+
+    def from_name(self, name):
+        self._name: str = name
+        self._path_name: str = name
+        self.object_ref: str = f'{self.cd.get_obj_type_path(self.object_type)}{self._path_name}'
+
+    @property
+    def object_type(self):
+        return f'resource/{self.resource_type.name}'
+
+    @staticmethod
+    def hash_name(name):
+        return name
+
+    @classmethod
+    def create(cls, resource_type: str, name: str, owner: str = None, **kwargs) -> 'ResourceId':
+        ops = []
+        new_node = cls(resource_type, name=name)
+        _owner = owner if owner else "fusillade"
+        ops.append(new_node.cd.batch_create_object(
+            f'{new_node.resource_type.object_ref}/id',
+            new_node.name,
+            new_node._facet,
+            new_node.cd.get_object_attribute_list(facet=new_node._facet, name=name, created_by=_owner, **kwargs)
+        ))
+        if owner:
+            ops.append(User(name=owner).batch_add_ownership(new_node))
+        try:
+            new_node.cd.batch_write(ops)
+        except cd_client.exceptions.BatchWriteException as ex:
+            if 'LinkNameAlreadyInUseException' in ex.response['Error']['Message']:
+                raise FusilladeHTTPException(
+                    status=409, title="Conflict", detail=f"The {cls.object_type} named {name} already exists. "
+                    f"{cls.object_type} was not modified.")
+            else:
+                raise FusilladeHTTPException(ex)
+        else:
+            new_node.cd.get_object_information(new_node.object_ref, ConsistencyLevel=ConsistencyLevel.SERIALIZABLE.name)
+            logger.info(dict(message=f"{new_node.object_type} created",
+                             creator=_owner,
+                             object=dict(type=new_node.object_type, path_name=new_node._path_name)))
+            return new_node
+
+    def add_principals(self, principals: List[Type['CloudNode']], access_level):
+        """
+        add a typed linked from resource to principal with the access type.
+        verifies that the policy exists before making link
+
+        :param principal_type:
+        :param name:
+        :param access_level:
+        :return:
+        """
+        # Check policy exists
+        self.resource_type.policy_exists(access_level)
+        p = defaultdict(list)
+        for principal in principals:
+            p[principal.object_type].append(principal.name)
+        operations = []
+        for object_type, links in p.items():
+            operations.extend(self._add_typed_links_batch(
+                links,
+                object_type,
+                'access_link',
+                {'access_level': access_level,
+                 'resource': self.object_type,
+                 'principal': object_type},
+                incoming=True))
+        self.cd.batch_write(operations)
+        self._principals = None  # update roles
+        logger.info(dict(message="Changed resource access permission for principals.",
+                         resource=dict(type=self.object_type, path_name=self._path_name),
+                         principals=p,
+                         access_level=access_level
+                         ))
+
+    def remove_principal(self, principal):
+        raise NotImplementedError()
+
+    def delete_node(self):
+        try:
+            self.cd.delete_object(self.object_ref, traverse=True)
+        except cd_client.exceptions.ResourceNotFoundException:
+            raise FusilladeNotFoundException(f"Failed to delete {self.name}. {self.object_type} does not exist.")
+
+    def check_access(self, principal: Type['CloudNode']) -> str:
+        tls = self.cd.make_typed_link_specifier(
+            self.object_ref,
+            principal.object_ref,
+            'access_link',
+            {'principal': principal.object_type,
+             'resource': self.resource_type.name})
+        try:
+            self.cd.get_link_attributes(tls, ['access_level'])
+        except cd_client.exceptions.ResourceNotFoundException:
+            return False
+        else:
+            return True

--- a/fusillade/resource.py
+++ b/fusillade/resource.py
@@ -18,7 +18,7 @@ import os
 from collections import defaultdict
 from typing import List, Dict, Any, Type, Union
 
-from fusillade.clouddirectory import CloudNode, cd_client, ConsistencyLevel, logger, \
+from fusillade.clouddirectory import CloudNode, Principal, cd_client, ConsistencyLevel, logger, \
     UpdateObjectParams, ValueTypes, UpdateActions, User
 from fusillade.errors import FusilladeHTTPException, FusilladeNotFoundException, FusilladeBadRequestException
 from fusillade.policy.validator import verify_iam_policy
@@ -388,7 +388,7 @@ class ResourceId(CloudNode):
                              object=dict(type=new_node.object_type, path_name=new_node._path_name)))
             return new_node
 
-    def add_principals(self, principals: List[Type['CloudNode']], access_level):
+    def add_principals(self, principals: List[Type['Principal']], access_level):
         """
         add a typed linked from resource to principal with the access type.
         verifies that the policy exists before making link
@@ -420,7 +420,7 @@ class ResourceId(CloudNode):
                          access_level=access_level
                          ))
 
-    def remove_principals(self, principals: List[Type['CloudNode']]):
+    def remove_principals(self, principals: List[Type['Principal']]):
         p = defaultdict(list)
         for principal in principals:
             p[principal.object_type].append(principal)
@@ -439,7 +439,7 @@ class ResourceId(CloudNode):
                          principals=p,
                          ))
 
-    def update_principal(self, principal: Type['CloudNode'], access_level: str):
+    def update_principal(self, principal: Type['Principal'], access_level: str):
         tls = self.cd.make_typed_link_specifier(
             principal.object_ref,
             self.object_ref,
@@ -460,7 +460,7 @@ class ResourceId(CloudNode):
         except cd_client.exceptions.ResourceNotFoundException:
             raise FusilladeNotFoundException(f"Failed to delete {self.name}. {self.object_type} does not exist.")
 
-    def check_access(self, principal: Type['CloudNode']) -> str:
+    def check_access(self, principal: Type['Principal']) -> str:
         tls = self.cd.make_typed_link_specifier(
             principal.object_ref,
             self.object_ref,

--- a/fusillade/resource.py
+++ b/fusillade/resource.py
@@ -404,12 +404,11 @@ class ResourceId(CloudNode):
         self.resource_type.policy_exists(access_level)
         p = defaultdict(list)
         for principal in principals:
-            p[principal.object_type].append(principal.name)
+            p[principal.object_type].append(principal)
         operations = []
         for object_type, links in p.items():
             operations.extend(self._add_typed_links_batch(
                 links,
-                object_type,
                 'access_link',
                 {'access_level': access_level,
                  'resource': self.object_type,

--- a/fusillade/resource.py
+++ b/fusillade/resource.py
@@ -16,7 +16,7 @@ perform on a resource.
 import json
 import os
 from collections import defaultdict
-from typing import List, Dict, Any, Type
+from typing import List, Dict, Any, Type, Union
 
 from fusillade.clouddirectory import CloudNode, cd_client, ConsistencyLevel, logger, \
     UpdateObjectParams, ValueTypes, UpdateActions, User

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -113,12 +113,21 @@ class TestResourceType(unittest.TestCase):
         test_type.remove_actions(more_actions)
         self.assertEqual(set(actions + new_actions), set(test_type.actions))
 
+    def test_resource_id(self):
+        resource_type = 'test_type'
+        test_type = self._create_resource_type(resource_type)
+
+        # add an access policy
+        test_type.create_policy('Reader', create_test_statement("resource policy", ['readproject']), 'ResourcePolicy')
+
+        test_id = test_type.create_id('ABCD')
+
         # list ids
-        projects = projects_type.list_ids()
-        self.assertTrue(projects)
+        test_types = test_type.list_ids()
+        self.assertTrue(test_types)
 
         # give a user read access to the id
-        project.add_principals(User('public'))
+        test_id.add_principals([User('public')], 'Reader')
 
 
 if __name__ == '__main__':

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -127,7 +127,19 @@ class TestResourceType(unittest.TestCase):
         self.assertTrue(test_types)
 
         # give a user read access to the id
-        test_id.add_principals([User('public')], 'Reader')
+        user = User('public')
+        test_id.add_principals([user], 'Reader')
+        self.assertEqual(test_id.check_access(user), 'Reader')
+
+        # update access
+        test_type.create_policy('RW', create_test_statement("resource policy", ['readproject', 'writeproject']),
+                                'ResourcePolicy')
+        test_id.update_principal(user, 'RW')
+        self.assertEqual(test_id.check_access(user), 'RW')
+
+        # remove access
+        test_id.remove_principals([user])
+        self.assertEqual(test_id.check_access(user), None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Summary
This PR is part of the effort to add resource ACL to fusillade. A new resource type is created by providing the name of the resource type, and the actions that can be performed on it. Once a resource type is created you can store specific ids of the resource you'd like to control. A principal only has access to resource they are give access to, either directly or through group membership. The creator of a resource ID is automatically designated as the owner of the resource. The owner of a resource can add additional owners, and assign access levels to their resource. The different levels of access are defined by access policies associated with a resource type. New access policies can be defined for a resource type after the resource type has been created. All resources of that type share the same access policies and can only be assigned access policies that have already been defined. Access policies can only define policies that use actions supported by that resource type. Actions can be added and removed after a resource type has been created. If a resource type is deleted, all access policies and resource ids associated with that type are deleted.

### Old Structure
![Fusillade Cloud Directory Structure - Page 8 (1)](https://user-images.githubusercontent.com/1429913/68880998-2c4e3880-06c1-11ea-981e-5543c9d6b795.png)

### New Structure
![Fusillade Cloud Directory Structure - Page 8](https://user-images.githubusercontent.com/1429913/68880862-eee9ab00-06c0-11ea-8f42-bb1cec6a4c6c.png)

# Release Notes

- support CRUD for resource Types
- support CRUD for resource Ids
- support verifying resource policies
- support CRUD for principal access to resource