### PR TITLE
using cloudNode directly

### DIFF
--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -1174,20 +1174,19 @@ class CloudNode:
             operations.append(batch_attach_typed_link(source, target, link_type, attributes))
         return operations
 
-    def _remove_links_batch(self, links: List[str], link_type: str, incoming=False):
+    def _remove_links_batch(self, links: List[Type['CloudNode']], incoming=False):
         """
         Removes links from this object in CloudDirectory.
         """
         if not links:
             return []
-        link_path = self.cd.get_obj_type_path(link_type)
         batch_detach_object = self.cd.batch_detach_object
         operations = []
         for link in links:
             if incoming:
-                source, target = f"{link_path}{self.hash_name(link)}", self.object_ref
+                source, target = link.object_ref, self.object_ref
             else:
-                source, target = self.object_ref, f"{link_path}{self.hash_name(link)}"
+                source, target = self.object_ref, link.object_ref
             operations.append(
                 batch_detach_object(
                     target,
@@ -1538,7 +1537,7 @@ class RolesMixin:
     def add_roles(self, roles: List[str]):
         operations = []
         _roles = [Role(role) for role in roles]
-        operations.extend(self._add_links_batch([Role(role) for role in roles]))
+        operations.extend(self._add_links_batch(_roles))
         operations.extend(self._add_typed_links_batch(_roles,
                                                       'membership_link',
                                                       {'member_of': Role.object_type}))

--- a/fusillade/clouddirectory.py
+++ b/fusillade/clouddirectory.py
@@ -1137,17 +1137,16 @@ class CloudNode:
                 get_links(self.object_ref, filter_attribute_range, facet)
             ]
 
-    def _add_links_batch(self, links: List[str], object_Type: str):
+    def _add_links_batch(self, links: List[Type['CloudNode']]):
         """
         Attaches links to this object in CloudDirectory.
         """
         if not links:
             return []
-        parent_path = self.cd.get_obj_type_path(object_Type)
         batch_attach_object = self.cd.batch_attach_object
         operations = []
         for link in links:
-            parent_ref = f"{parent_path}{self.hash_name(link)}"
+            parent_ref = link.object_ref
             operations.append(
                 batch_attach_object(
                     parent_ref,
@@ -1157,7 +1156,7 @@ class CloudNode:
             )
         return operations
 
-    def _add_typed_links_batch(self, links: List[str], object_type, link_type: str, attributes: Dict, incoming=False):
+    def _add_typed_links_batch(self, links: List[Type['CloudNode']], link_type: str, attributes: Dict, incoming=False):
         """
         Attaches links to this object in CloudDirectory.
 
@@ -1165,14 +1164,13 @@ class CloudNode:
         """
         if not links:
             return []
-        link_path = self.cd.get_obj_type_path(object_type)
         batch_attach_typed_link = self.cd.batch_attach_typed_link
         operations = []
         for link in links:
             if incoming:
-                source, target = f"{link_path}{self.hash_name(link)}", self.object_ref
+                source, target = link.object_ref, self.object_ref
             else:
-                source, target = self.object_ref, f"{link_path}{self.hash_name(link)}"
+                source, target = self.object_ref, link.object_ref
             operations.append(batch_attach_typed_link(source, target, link_type, attributes))
         return operations
 
@@ -1198,22 +1196,21 @@ class CloudNode:
             )
         return operations
 
-    def _remove_typed_links_batch(self, links: List[str], object_type, link_type: str, attributes: Dict,
+    def _remove_typed_links_batch(self, links: List[Type['CloudNode']], link_type: str, attributes: Dict,
                                   incoming=False):
         """
         Removes links from this object in CloudDirectory.
         """
         if not links:
             return []
-        link_path = self.cd.get_obj_type_path(object_type)
         batch_detach_typed_link = self.cd.batch_detach_typed_link
         make_typed_link_specifier = self.cd.make_typed_link_specifier
         operations = []
         for link in links:
             if incoming:
-                source, target = f"{link_path}{self.hash_name(link)}", self.object_ref
+                source, target = link.object_ref, self.object_ref
             else:
-                source, target = self.object_ref, f"{link_path}{self.hash_name(link)}"
+                source, target = self.object_ref, link.object_ref
             typed_link_specifier = make_typed_link_specifier(
                 source,
                 target,
@@ -1540,9 +1537,9 @@ class RolesMixin:
 
     def add_roles(self, roles: List[str]):
         operations = []
-        operations.extend(self._add_links_batch(roles, Role.object_type))
-        operations.extend(self._add_typed_links_batch(roles,
-                                                      Role.object_type,
+        _roles = [Role(role) for role in roles]
+        operations.extend(self._add_links_batch([Role(role) for role in roles]))
+        operations.extend(self._add_typed_links_batch(_roles,
                                                       'membership_link',
                                                       {'member_of': Role.object_type}))
         self.cd.batch_write(operations)
@@ -1553,9 +1550,9 @@ class RolesMixin:
 
     def remove_roles(self, roles: List[str]):
         operations = []
-        operations.extend(self._remove_links_batch(roles, Role.object_type))
-        operations.extend(self._remove_typed_links_batch(roles,
-                                                         Role.object_type,
+        _roles = [Role(role) for role in roles]
+        operations.extend(self._remove_links_batch(_roles))
+        operations.extend(self._remove_typed_links_batch(_roles,
                                                          'membership_link',
                                                          {'member_of': Role.object_type}))
         self.cd.batch_write(operations)
@@ -1821,8 +1818,7 @@ class User(Principal):
             raise FusilladeLimitException(
                 f"Failed to add groups [{groups}]. The user belongs to {len(self.groups)} groups. "
                 f"Only {Config.group_max - len(self.groups)} can be added.")
-        operations.extend(self._add_typed_links_batch(groups,
-                                                      Group.object_type,
+        operations.extend(self._add_typed_links_batch([Group(group) for group in groups],
                                                       'membership_link',
                                                       {'member_of': Group.object_type}))
         if run:
@@ -1836,8 +1832,7 @@ class User(Principal):
 
     def remove_groups(self, groups: List[str], run=True):
         operations = []
-        operations.extend(self._remove_typed_links_batch(groups,
-                                                         Group.object_type,
+        operations.extend(self._remove_typed_links_batch([Group(group) for group in groups],
                                                          'membership_link',
                                                          {'member_of': Group.object_type}))
         if run:


### PR DESCRIPTION
- This allows object that inherit CloudNode to use their own hash_name function when adding links.

