### PR TITLE
Simplify attribute parsing

### DIFF
--- a/fusillade/api/evaluate.py
+++ b/fusillade/api/evaluate.py
@@ -23,7 +23,7 @@ def evaluate_policy_api(token_info, body):  # TODO allow context variables to be
                 body['principal'],
                 body['action'],
                 body['resource'],
-                authz_params['policies'],
+                authz_params['IAMPolicy'],
                 context_entries=restricted_context_entries(authz_params))
     return make_response(jsonify(**response), 200)
 

--- a/fusillade/directory/__init__.py
+++ b/fusillade/directory/__init__.py
@@ -552,7 +552,7 @@ class User(Principal):
         :return: a set of actions the users can perform
         """
         statements = list(itertools.chain.from_iterable(
-            [json.loads(p['policy'])['Statement'] for p in self.get_authz_params()['policies']]))
+            [json.loads(p['policy_document'])['Statement'] for p in self.get_authz_params()['IAMPolicy']]))
         actions = list(itertools.chain.from_iterable([s['Action'] for s in statements if s['Effect'] == 'Allow']))
 
         # Need to handle cases where the actions has a wildcard. All actions that match the wildcard are removed and

--- a/fusillade/utils/authorize.py
+++ b/fusillade/utils/authorize.py
@@ -27,7 +27,7 @@ def get_policy_statement(evaluation_results: List[Dict[str, Any]], policies: Lis
             begin = ms['StartPosition']['Column']
             end = ms['EndPosition']['Column']
             policy = policies[policy_index]
-            ms['statement'] = policy['policy'][begin:end]
+            ms['statement'] = policy['policy_document'][begin:end]
             ms['SourcePolicyId'] = policy['name']
             ms['SourcePolicyType'] = policy['type']
     return evaluation_results

--- a/fusillade/utils/authorize.py
+++ b/fusillade/utils/authorize.py
@@ -43,7 +43,7 @@ def evaluate_policy(
     context_entries = context_entries if context_entries else []
     eval_results = []
     params = dict(
-        PolicyInputList=[policy['policy'] for policy in policies],
+        PolicyInputList=[policy['policy_document'] for policy in policies],
         ActionNames=actions,
         ResourceArns=resources,
         ContextEntries=[
@@ -107,7 +107,12 @@ def assert_authorized(user, actions, resources, context_entries=None):
         raise FusilladeForbiddenException(detail="User must be enabled to make authenticated requests.")
     else:
         context_entries.extend(restricted_context_entries(authz_params))
-        if not evaluate_policy(user, actions, resources, authz_params['policies'], context_entries)['result']:
+        if not evaluate_policy(
+                user,
+                actions,
+                resources,
+                authz_params['IAMPolicy'],
+                context_entries=context_entries)['result']:
             logger.info(dict(message="User not authorized.", user=u._path_name, action=actions, resources=resources))
             raise FusilladeForbiddenException()
         else:

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -50,7 +50,7 @@ class TestGroup(unittest.TestCase, AssertJSONMixin):
     def test_policy(self):
         group = Group.create("new_group")
         with self.subTest("Only one policy is attached when lookup policy is called on a group without any roles"):
-            policies = [p['policy'] for p in group.get_authz_params()['policies']]
+            policies = [p['policy_document'] for p in group.get_authz_params()['IAMPolicy']]
             self.assertEqual(len(policies), 1)
             self.assertJSONEqual(policies[0], self.default_group_statement)
 
@@ -58,7 +58,7 @@ class TestGroup(unittest.TestCase, AssertJSONMixin):
         statement = create_test_IAMPolicy(group_name)
         with self.subTest("The group policy changes when satement is set"):
             group.set_policy(statement)
-            policies = [p['policy'] for p in group.get_authz_params()['policies']]
+            policies = [p['policy_document'] for p in group.get_authz_params()['IAMPolicy']]
             self.assertJSONEqual(policies[0], statement)
 
         with self.subTest("error raised when invalid statement assigned to group.get_policy()."):
@@ -108,7 +108,7 @@ class TestGroup(unittest.TestCase, AssertJSONMixin):
             group.add_roles(roles)
             self.assertEqual(len(group.roles), 2)
         with self.subTest("policies inherited from roles are returned when lookup policies is called"):
-            group_policies = sorted([normalize_json(p['policy']) for p in group.get_authz_params()['policies']])
+            group_policies = sorted([normalize_json(p['policy_document']) for p in group.get_authz_params()['IAMPolicy']])
             role_policies = sorted([normalize_json(role.get_policy()) for role in role_objs] + [
                 self.default_group_statement])
             self.assertListEqual(group_policies, role_policies)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -49,13 +49,13 @@ class TestUser(unittest.TestCase, AssertJSONMixin):
         user = User(name)
         with self.subTest("new user is automatically provisioned on demand with default settings when "
                           "lookup_policy is called for a new user."):
-            self.assertJSONListEqual([p['policy'] for p in user.get_authz_params()['policies']],
+            self.assertJSONListEqual([p['policy_document'] for p in user.get_authz_params()['IAMPolicy']],
                                      self.default_user_policies)
         with self.subTest("error is returned when provision_user is called for an existing user"):
             self.assertRaises(FusilladeHTTPException, user.provision_user, name)
         with self.subTest("an existing users info is retrieved when instantiating User class for an existing user"):
             user = User(name)
-            self.assertJSONListEqual([p['policy'] for p in user.get_authz_params()['policies']],
+            self.assertJSONListEqual([p['policy_document'] for p in user.get_authz_params()['IAMPolicy']],
                                      self.default_user_policies)
 
     def test_get_groups(self):
@@ -88,7 +88,7 @@ class TestUser(unittest.TestCase, AssertJSONMixin):
             self.assertEqual(len(user.groups), 6)
 
         with self.subTest("A user inherits the groups policies when joining a group"):
-            policies = set([normalize_json(p['policy']) for p in user.get_authz_params()['policies']])
+            policies = set([normalize_json(p['policy_document']) for p in user.get_authz_params()['IAMPolicy']])
             expected_policies = set([normalize_json(i[1]) for i in test_groups])
             expected_policies.update(self.default_user_policies)
             self.assertSetEqual(policies, expected_policies)
@@ -125,14 +125,14 @@ class TestUser(unittest.TestCase, AssertJSONMixin):
         with self.subTest("The user policy is set when statement setter is used."):
             expected_statement = statement
             self.assertJSONEqual(user.get_policy(), expected_statement)
-            self.assertJSONIn(expected_statement, [p['policy'] for p in user.get_authz_params()['policies']])
+            self.assertJSONIn(expected_statement, [p['policy_document'] for p in user.get_authz_params()['IAMPolicy']])
 
         statement = create_test_IAMPolicy(f"UserPolicySomethingElse2")
         user.set_policy(statement)
         with self.subTest("The user policy changes when set_policy is used."):
             expected_statement = statement
             self.assertJSONEqual(user.get_policy(), expected_statement)
-            self.assertJSONIn(expected_statement, [p['policy'] for p in user.get_authz_params()['policies']])
+            self.assertJSONIn(expected_statement, [p['policy_document'] for p in user.get_authz_params()['IAMPolicy']])
 
         with self.subTest("Error raised when setting policy to an invalid statement"):
             with self.assertRaises(FusilladeHTTPException):
@@ -183,7 +183,7 @@ class TestUser(unittest.TestCase, AssertJSONMixin):
 
         user.set_policy(self.default_policy)
         with self.subTest("A user inherits a roles policies when a role is added to a user."):
-            policies = [p['policy'] for p in user.get_authz_params()['policies']]
+            policies = [p['policy_document'] for p in user.get_authz_params()['IAMPolicy']]
             self.assertJSONListEqual(policies, [user.get_policy(), role_statement, *self.default_user_policies])
 
         with self.subTest("A role is removed from user when remove role is called."):
@@ -196,7 +196,7 @@ class TestUser(unittest.TestCase, AssertJSONMixin):
             self.assertEqual(sorted(user_role_names), role_names)
 
         with self.subTest("A user inherits multiple role policies when the user has multiple roles."):
-            policies = [p['policy'] for p in user.get_authz_params()['policies']]
+            policies = [p['policy_document'] for p in user.get_authz_params()['IAMPolicy']]
             self.assertJSONListEqual(policies, [user.get_policy(), *self.default_user_policies, *role_statements])
 
         with self.subTest("A user's roles are listed when a listing a users roles."):
@@ -235,7 +235,7 @@ class TestUser(unittest.TestCase, AssertJSONMixin):
         authz_params = user.get_authz_params()
         self.assertListEqual(sorted(authz_params['roles']), sorted(['default_user'] + role_names))
         self.assertListEqual(sorted(authz_params['groups']), sorted(['user_default'] + group_names))
-        self.assertJSONListEqual([p['policy'] for p in authz_params['policies']],
+        self.assertJSONListEqual([p['policy_document'] for p in authz_params['IAMPolicy']],
                                  [user.get_policy(), *self.default_user_policies] + group_statements + role_statements)
 
     def test_ownership(self):


### PR DESCRIPTION
- Rename 'policies' to 'IAMPolicy', this is to prepare for the addition of 'ResourcePolicy'
- Rename 'policy' to 'policy_document', this matches closer with cloud directories naming scheme.
- adding parse_attributes to simplify parsing of attributes from cloud directory requests

<!--
Please make sure to provide a meaningful title for your PR. 
Do not keep the default title.
-->

<!--
Use GitHub keywords "fixes" or "closes" followed by an issue number if your PR
completely resolves an issue:
"Fixes #123" or "Closes #456"
-->

<!-- 
Describe how you tested this PR, and how you will test the feature after it is
merged. Uncomment below:

### Test plan
-->

<!--
Describe any special instructions to the operator who will deploy your code to
the integration, staging and production deployments. Uncomment below:

### Deployment instructions & migrations
-->

<!-- 
Add notes to highlight the feature when it's released/demoed. Uncomment the
headings below:

### Release notes
-->

<!--
Do you want your PR to be merged by the reviewer using squash or rebase
merging? If so, mention it here.
-->

