### PR TITLE
Adding resource based access control to permission evaluation

### DIFF
--- a/fusillade/api/evaluate.py
+++ b/fusillade/api/evaluate.py
@@ -4,7 +4,7 @@ from threading import Thread
 
 from flask import make_response, jsonify
 
-from fusillade import User
+from fusillade.directory.authorization import get_resource_authz_parameters
 from fusillade.errors import AuthorizationException
 from fusillade.utils.authorize import assert_authorized, evaluate_policy, restricted_context_entries, get_email_claim
 
@@ -15,7 +15,7 @@ def evaluate_policy_api(token_info, body):  # TODO allow context variables to be
                          ['fus:Evaluate'],
                          ['arn:hca:fus:*:*:user']):
         try:
-            authz_params = User(body['principal']).get_authz_params()
+            authz_params = get_resource_authz_parameters(body['principal'], body['resource'])
         except AuthorizationException:
             response = {'result': False, 'reason': "The user is disabled."}
         else:
@@ -24,6 +24,7 @@ def evaluate_policy_api(token_info, body):  # TODO allow context variables to be
                 body['action'],
                 body['resource'],
                 authz_params['IAMPolicy'],
+                authz_params.get('ResourcePolicy'),
                 context_entries=restricted_context_entries(authz_params))
     return make_response(jsonify(**response), 200)
 

--- a/fusillade/utils/authorize.py
+++ b/fusillade/utils/authorize.py
@@ -31,12 +31,12 @@ def get_policy_statement(evaluation_results: List[Dict[str, Any]],
                 policy_index = int(ms['SourcePolicyId'].split('.')[-1]) - 1
             except ValueError:
                 if resource_policy:
-                    ms['statement'] = resource_policy[begin:end]
+                    ms['Statement'] = resource_policy[begin:end]
                     ms['SourcePolicyId'] = 'ResourcePolicy'
                     ms['SourcePolicyType'] = 'ResourcePolicy'
                 else:
                     logging.warning({"msg": "Failed to parse evaluation response.",
-                                     "matched_statement": ms,
+                                     "MatchedStatements": ms,
                                      "policies": policies,
                                      "resource_policy": resource_policy})
                     continue


### PR DESCRIPTION
- sending IAM and Resource policies for user and resource to the policy simulator.
- modifying the request to the policy simulator to accept resource policies if they exist
- adding logic to add ResourcePolicy information to the evaluate_policy response when a ResourcePolicy matches a statement used in the policy simulation.
- adding test cases to evaluate_policy works with resource policies.

<!--
Please make sure to provide a meaningful title for your PR. 
Do not keep the default title.
-->

<!--
Use GitHub keywords "fixes" or "closes" followed by an issue number if your PR
completely resolves an issue:
"Fixes #123" or "Closes #456"
-->

<!-- 
Describe how you tested this PR, and how you will test the feature after it is
merged. Uncomment below:

### Test plan
-->

<!--
Describe any special instructions to the operator who will deploy your code to
the integration, staging and production deployments. Uncomment below:

### Deployment instructions & migrations
-->

<!-- 
Add notes to highlight the feature when it's released/demoed. Uncomment the
headings below:

### Release notes
-->

<!--
Do you want your PR to be merged by the reviewer using squash or rebase
merging? If so, mention it here.
-->

