### PR TITLE
Adding get_authz_params

### DIFF
--- a/fusillade/directory/authorization.py
+++ b/fusillade/directory/authorization.py
@@ -1,0 +1,34 @@
+from typing import List, Union
+
+from fusillade import Config
+from fusillade.directory import User, Group
+from fusillade.directory.resource import ResourceId, ResourceType
+from fusillade.errors import FusilladeForbiddenException
+from fusillade.policy.resource_policy import combine
+
+
+def get_resource_authz_parameters(user: str, resources: Union[List[str], str]):
+    """
+
+    Get all policy ids, and send them to lookup policy, group them by policy type.
+
+    :param user:
+    :param resource:
+    :return:
+    """
+    policies = []
+    _user = User(user)
+    # Only support a single resource for now
+    resource = resources[0] if isinstance(resources, list) else resources
+    r_type, r_id, *_ = resource.split(':')[-1].split('/')
+    if r_type in ResourceType.get_types():
+        r_id = ResourceId(r_type, r_id)
+        resource_policies = r_id.check_access([_user] + [Group(g) for g in _user.groups])
+        if not resource_policies:
+            raise FusilladeForbiddenException()
+        policies.extend(resource_policies)
+    policies.extend(list(_user.get_policy_ids()))
+    authz_params = Config.get_directory().get_policies(policies)
+    if authz_params.get('ResourcePolicy'):
+        authz_params['ResourcePolicy'] = combine([i['policy_document'] for i in authz_params.get('ResourcePolicy')])
+    return authz_params

--- a/fusillade/policy/resource_policy.py
+++ b/fusillade/policy/resource_policy.py
@@ -1,0 +1,9 @@
+import json
+from typing import List
+
+
+def combine(policies: List[str]) -> str:
+    statements = []
+    for p in policies:
+        statements.extend(json.loads(p)['Statement'])
+    return json.dumps(dict(Version="2012-10-17", Statement=statements))

--- a/fusillade/utils/json.py
+++ b/fusillade/utils/json.py
@@ -1,7 +1,15 @@
 import json
-from typing import Dict, Any
+from typing import Dict, Any, Union
 
 
 def get_json_file(file_name) -> Dict[str, Any]:
     with open(file_name, 'r') as fp:
         return json.load(fp)
+
+
+def json_equal(a: Union[dict, str], b: Union[dict, str]):
+    a = json.loads(a) if isinstance(a, str) else a
+    a = json.dumps(a, sort_keys=True)
+    b = json.loads(b) if isinstance(b, str) else b
+    b = json.dumps(b, sort_keys=True)
+    return a == b

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import unittest
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from fusillade.utils.json import json_equal
+from fusillade.directory.authorization import get_resource_authz_parameters
+
+from fusillade.directory import cleanup_directory, cleanup_schema, User, clear_cd
+from fusillade.errors import FusilladeForbiddenException
+from fusillade.directory.resource import ResourceType
+from tests.common import new_test_directory
+from tests.infra.testmode import standalone
+
+
+@standalone
+class TestEvaluate(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.directory, cls.schema_arn = new_test_directory()
+
+    @classmethod
+    def tearDownClass(cls):
+        cleanup_directory(cls.directory._dir_arn)
+        cleanup_schema(cls.schema_arn)
+
+    def tearDown(self):
+        clear_cd(self.directory)
+
+    def test_get_authz_params(self):
+        actions = ['test:readproject', 'test:writeproject', 'test:deleteproject']
+        arn_prefix = "arn:dcp:fus:us-east-1:dev:"
+        resource_type = 'test_type'
+        test_type = ResourceType.create(resource_type, actions)
+        access_level = 'Reader'
+        resource_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Principal": "*",
+                    "Sid": "project_reader",
+                    "Effect": "Allow",
+                    "Action": ['test:readproject'],
+                    "Resource": f"{arn_prefix}{resource_type}/*"
+                }
+            ]
+        }
+        test_type.create_policy(access_level, resource_policy, 'ResourcePolicy')
+        user = User.provision_user('test_user')
+        type_id = '1234455'
+        resource = f'{arn_prefix}{resource_type}/{type_id}'
+
+        with self.subTest("A user has no access when no access level set between user and resource"):
+            with self.assertRaises(FusilladeForbiddenException):
+                get_resource_authz_parameters(user.name, resource)
+
+        with self.subTest("No resource policy parameters are returned when the user tries to access a resource that "
+                          "does not use resource policies"):
+            params = get_resource_authz_parameters(user.name, f"{arn_prefix}non_acl_resource/1234")
+            self.assertFalse(params.get('ResourcePolicy'))
+            self.assertFalse(params.get('resources'))
+
+        with self.subTest("The resource policy for the access level assigned to the user is returned when a user "
+                          "is given access to a resource"):
+            test_id = test_type.create_id(type_id)
+            test_id.add_principals([user], access_level)
+            params = get_resource_authz_parameters(user.name, resource)
+            self.assertTrue(json_equal(params['ResourcePolicy'], resource_policy))
+            self.assertEqual(['Reader'], params['resources'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This will retrieve resource policies and IAMpolicies for a user and resource. These will later be used with evaluate to a users access to a resource.

- adding function to combine resource policies. This is needed because the policy simulator API only accepts a single resource policy to simulate.

<!--
Please make sure to provide a meaningful title for your PR. 
Do not keep the default title.
-->

<!--
Use GitHub keywords "fixes" or "closes" followed by an issue number if your PR
completely resolves an issue:
"Fixes #123" or "Closes #456"
-->

<!-- 
Describe how you tested this PR, and how you will test the feature after it is
merged. Uncomment below:

### Test plan
-->

<!--
Describe any special instructions to the operator who will deploy your code to
the integration, staging and production deployments. Uncomment below:

### Deployment instructions & migrations
-->

<!-- 
Add notes to highlight the feature when it's released/demoed. Uncomment the
headings below:

### Release notes
-->

<!--
Do you want your PR to be merged by the reviewer using squash or rebase
merging? If so, mention it here.
-->

