### PR TITLE
Adding ResourceNotFound Error when user does not have access to resource

### DIFF
--- a/fusillade/api/evaluate.py
+++ b/fusillade/api/evaluate.py
@@ -5,7 +5,7 @@ from threading import Thread
 from flask import make_response, jsonify
 
 from fusillade.directory.authorization import get_resource_authz_parameters
-from fusillade.errors import AuthorizationException
+from fusillade.errors import AuthorizationException, ResourceNotFound
 from fusillade.utils.authorize import assert_authorized, evaluate_policy, restricted_context_entries, get_email_claim
 
 
@@ -17,7 +17,9 @@ def evaluate_policy_api(token_info, body):  # TODO allow context variables to be
         try:
             authz_params = get_resource_authz_parameters(body['principal'], body['resource'])
         except AuthorizationException:
-            response = {'result': False, 'reason': "The user is disabled."}
+            response = {'result': False, 'reason': "UserDisabled"}
+        except ResourceNotFound as ex:
+            response = {'result': False, 'reason': ex.reason, 'details': 'The requested resource does not exist.'}
         else:
             response = evaluate_policy(
                 body['principal'],

--- a/fusillade/directory/authorization.py
+++ b/fusillade/directory/authorization.py
@@ -4,7 +4,7 @@ from dcplib.aws.clients import clouddirectory as cd_client
 from fusillade import Config
 from fusillade.directory import User, Group
 from fusillade.directory.resource import ResourceId, ResourceType
-from fusillade.errors import FusilladeForbiddenException
+from fusillade.errors import ResourceNotFound
 from fusillade.policy.resource_policy import combine
 
 
@@ -32,7 +32,7 @@ def get_resource_authz_parameters(user: str, resources: Union[List[str], str]):
         r_id = ResourceId(r_type, r_id)
         resource_policies = r_id.check_access([_user] + [Group(g) for g in groups])
         if not resource_policies:
-            raise FusilladeForbiddenException()
+            raise ResourceNotFound("ResourceNotFound")
         policies.extend(resource_policies)
     policies.extend(list(_user.get_policy_ids()))
     authz_params = Config.get_directory().get_policies(policies)

--- a/fusillade/errors.py
+++ b/fusillade/errors.py
@@ -20,6 +20,12 @@ class AuthorizationException(FusilladeException):
         self.reason = reason
 
 
+class ResourceNotFound(FusilladeException):
+    def __init__(self, reason, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.reason = reason
+
+
 class FusilladeHTTPException(ProblemException):
     pass
 
@@ -52,6 +58,7 @@ class FusilladeForbiddenException(FusilladeHTTPException):
                          title="Forbidden",
                          detail=detail,
                          *args, **kwargs)
+
 
 class FusilladeTooManyRequestsException(FusilladeHTTPException):
     def __init__(self, detail: str = "Rate limit reached. Try again in 30 seconds.",

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -9,7 +9,7 @@ from fusillade.utils.json import json_equal
 from fusillade.directory.authorization import get_resource_authz_parameters
 from fusillade.utils.authorize import evaluate_policy
 from fusillade.directory import cleanup_directory, cleanup_schema, User, clear_cd, Role
-from fusillade.errors import FusilladeForbiddenException, ResourceNotFound, AuthorizationException
+from fusillade.errors import ResourceNotFound, AuthorizationException
 from fusillade.directory.resource import ResourceType
 from tests.common import new_test_directory
 from tests.infra.testmode import standalone

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -9,7 +9,7 @@ from fusillade.utils.json import json_equal
 from fusillade.directory.authorization import get_resource_authz_parameters
 from fusillade.utils.authorize import evaluate_policy
 from fusillade.directory import cleanup_directory, cleanup_schema, User, clear_cd, Role
-from fusillade.errors import FusilladeForbiddenException
+from fusillade.errors import FusilladeForbiddenException, ResourceNotFound, AuthorizationException
 from fusillade.directory.resource import ResourceType
 from tests.common import new_test_directory
 from tests.infra.testmode import standalone
@@ -53,7 +53,7 @@ class TestEvaluate(unittest.TestCase):
         resource = f'{self.arn_prefix}{resource_type}/{type_id}'
 
         with self.subTest("A user has no access when no access level set between user and resource"):
-            with self.assertRaises(FusilladeForbiddenException):
+            with self.assertRaises(ResourceNotFound):
                 get_resource_authz_parameters(user.name, resource)
 
         with self.subTest("No resource policy parameters are returned when the user tries to access a resource that "
@@ -69,6 +69,11 @@ class TestEvaluate(unittest.TestCase):
             params = get_resource_authz_parameters(user.name, resource)
             self.assertTrue(json_equal(params['ResourcePolicy'], resource_policy))
             self.assertEqual(['Reader'], params['resources'])
+
+        with self.subTest("No access when the user is disabled."):
+            user.disable()
+            with self.assertRaises(AuthorizationException):
+                get_resource_authz_parameters(user.name, resource)
 
     def test_auto_provision(self):
         """A user is automatically provision if the user does not exist in cloud directory, when evaluating


### PR DESCRIPTION
When a user tries to access a controlled access resource they do not have any access privileges to, the object appears as if it does not exist. A user should not know about resources they do not have access to.

- ResourceNotFound error raised during evaluation if the user does not have access to the specified resource type or id.
- 
<!--
Please make sure to provide a meaningful title for your PR. 
Do not keep the default title.
-->

<!--
Use GitHub keywords "fixes" or "closes" followed by an issue number if your PR
completely resolves an issue:
"Fixes #123" or "Closes #456"
-->

<!-- 
Describe how you tested this PR, and how you will test the feature after it is
merged. Uncomment below:

### Test plan
-->

<!--
Describe any special instructions to the operator who will deploy your code to
the integration, staging and prod deployments. Uncomment below:

### Deployment instructions & migrations
-->

<!-- 
Add notes to highlight the feature when it's released/demoed. Uncomment the
headings below:

### Release notes
-->

<!--
Do you want your PR to be merged by the reviewer using squash or rebase
merging? If so, mention it here.
-->

