### PR TITLE
modify attribute parsing function to work for typed link attributes a…

### DIFF
--- a/fusillade/directory/clouddirectory.py
+++ b/fusillade/directory/clouddirectory.py
@@ -466,17 +466,20 @@ class CloudDirectory:
     @staticmethod
     def parse_attributes(attributes: List[Dict[str, Any]]) -> Dict[str, Any]:
         result = dict()
+        # check if we are parsing object attributes or typed link attributes
+        typed_link = attributes[0].get('Key') is None
         for attr in attributes:
+            key = attr['AttributeName'] if typed_link else attr['Key']['Name']
             if ValueTypes.StringValue.name in attr['Value'].keys():
-                result[attr['Key']['Name']] = attr['Value'][ValueTypes.StringValue.name]
+                result[key] = attr['Value'][ValueTypes.StringValue.name]
             elif ValueTypes.BinaryValue.name in attr['Value'].keys():
-                result[attr['Key']['Name']] = attr['Value'][ValueTypes.BinaryValue.name]
+                result[key] = attr['Value'][ValueTypes.BinaryValue.name]
             elif ValueTypes.BinaryValue.name in attr['Value'].keys():
-                result[attr['Key']['Name']] = attr['Value'][ValueTypes.BooleanValue.name]
+                result[key] = attr['Value'][ValueTypes.BooleanValue.name]
             elif ValueTypes.BinaryValue.name in attr['Value'].keys():
-                result[attr['Key']['Name']] = attr['Value'][ValueTypes.NumberValue.name]
+                result[key] = attr['Value'][ValueTypes.NumberValue.name]
             elif ValueTypes.BinaryValue.name in attr['Value'].keys():
-                result[attr['Key']['Name']] = attr['Value'][ValueTypes.DatetimeValue.name]
+                result[key] = attr['Value'][ValueTypes.DatetimeValue.name]
         return result
 
     def make_typed_link_specifier(


### PR DESCRIPTION
AWS Cloud Directory has two different shapes for storing attributes; one for object attributes and one for typed link attributes. The PR adds changes to the attribute parser to work for both shapes.