### PR TITLE
Resource id access levels

### DIFF
--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -1395,17 +1395,9 @@ paths:
         - $ref: '#/components/parameters/per_page'
       responses:
         200:
-          description: All results have been returned.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/members'
+          $ref: '#/components/responses/200_paged'
         206:
-          description: All results have been returned.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/members'
+          $ref: '#/components/responses/206'
         401:
           $ref: '#/components/responses/401'
         403:

--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -1380,6 +1380,69 @@ paths:
           description: Unexpected error.
       tags:
         - resource
+  /v1/resource/{resource_type_name}/id/{resource_id}/members:
+    get:
+      summary: List all members that have access to this resource.
+      description: List all members that have access to this resource. Members include users, and groups with any
+        level of access to this resource.
+      operationId: fusillade.api.resource.resource_type_name.id.resource_id.members.get
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+        - $ref: '#/components/parameters/resource_id'
+        - $ref: '#/components/parameters/next_token'
+        - $ref: '#/components/parameters/per_page'
+      responses:
+        200:
+          description: All results have been returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/members'
+        206:
+          description: All results have been returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/members'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+    put:
+      summary: Give a principal access defined by a {resource_policy} to {resource_type_name}/{resource_id}.
+      description:  Give a principal access defined by {policy_name} to {resource_type_name}/{resource_id}.
+      operationId: fusillade.api.resource.resource_type_name.id.resource_id.members.put
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+        - $ref: '#/components/parameters/resource_id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/resource_member'
+              maxItems: 1
+              minItems: 1
+      responses:
+        200:
+          description: The {type}/{entity_id} has been added to the policy.
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        default:
+          description: Unexpected error.
+      tags:
+        - resource
 components:
   parameters:
     user_id:
@@ -1460,6 +1523,9 @@ components:
       schema:
         type: string
   schemas:
+    principal_type:
+        type: string
+        enum: [user, group]
     paged_results:
       type: array
       items:
@@ -1481,9 +1547,38 @@ components:
           $ref: '#/components/schemas/paged_results'
         resource_type:
           type: string
+    resource_member:
+      type: object
+      properties:
+        member:
+          type: string
+        member_type:
+          $ref: '#/components/schemas/principal_type'
+        access_level:
+          type: string
+      required:
+        - member
+        - member_type
+      example:
+        Add or update access:
+          value:
+            member: i_am_a_user_name
+            member_type: user
+            access_level: read
+        Remove access:
+          value:
+            member: i_am_a_user_name
+            member_type: user
     policy_action:
       type: string
       pattern: '[A-z]\w*[^\W_]:[A-z]\w*[^\W_]'
+    members:
+      type: object
+      properties:
+        members:
+          type: array
+          items:
+            $ref: '#/components/schemas/resource_member'
     policy_document:
       description: A resource policy, used for controlling access to a resource.
       type: object
@@ -1614,6 +1709,7 @@ components:
               - $ref: '#/components/schemas/groups'
               - $ref: '#/components/schemas/roles'
               - $ref: '#/components/schemas/users'
+              - $ref: '#/components/schemas/members'
               - $ref: '#/components/schemas/resource_types'
               - $ref: '#/components/schemas/policies'
               - $ref: '#/components/schemas/resource_ids'
@@ -1638,6 +1734,7 @@ components:
               - $ref: '#/components/schemas/groups'
               - $ref: '#/components/schemas/roles'
               - $ref: '#/components/schemas/users'
+              - $ref: '#/components/schemas/members'
               - $ref: '#/components/schemas/resource_types'
               - $ref: '#/components/schemas/policies'
               - $ref: '#/components/schemas/resource_ids'

--- a/fusillade/api/resource/resource_type_name/id/resource_id/members/__init__.py
+++ b/fusillade/api/resource/resource_type_name/id/resource_id/members/__init__.py
@@ -1,0 +1,30 @@
+from flask import make_response, jsonify, request
+
+from fusillade.api.paging import get_page, get_next_token
+from fusillade.directory.resource import ResourceId
+from fusillade.utils.authorize import authorize
+
+
+@authorize(["fus:GetResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}/{resource_id}/members"],
+           resource_params=['resource_type_name', 'resource_id'])
+def get(token_info: dict, resource_type_name, resource_id):
+    next_token, per_page = get_next_token(request.args)
+    return get_page(
+        ResourceId(resource_type_name, resource_id).list_principals,
+        next_token,
+        per_page,
+        content_key='members')
+
+
+@authorize(["fus:PutResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}/{resource_id}/members"],
+           resource_params=['resource_type_name', 'resource_id'])
+def put(token_info: dict, resource_type_name, resource_id):
+    members = request.json
+    rt = ResourceId(resource_type_name, resource_id)
+    rt.modify_principals(members)
+    return make_response(jsonify({
+        'msg': f"Access levels modified.",
+        'resource_type': rt.name,
+        'resource_id': resource_id}), 200)

--- a/fusillade/directory/authorization.py
+++ b/fusillade/directory/authorization.py
@@ -30,7 +30,7 @@ def get_resource_authz_parameters(user: str, resources: Union[List[str], str]):
     r_type, r_id, *_ = resource.split(':')[-1].split('/')
     if r_type in ResourceType.get_types():
         r_id = ResourceId(r_type, r_id)
-        resource_policies = r_id.check_access([_user] + [Group(g) for g in groups])
+        resource_policies = r_id.check_access([_user] + [Group(object_ref=g) for g in groups])
         if not resource_policies:
             raise ResourceNotFound("ResourceNotFound")
         policies.extend(resource_policies)

--- a/fusillade/directory/resource.py
+++ b/fusillade/directory/resource.py
@@ -535,9 +535,9 @@ class ResourceId(CloudNode):
 
     def modify_principals(self, principals: List[Dict[str, str]]) -> None:
         """
-        modify a principals access to this resource id by adding, updating or deleting access levels as needed.
+        Modify a list of principals to grant them access to this resource id by adding, updating or deleting access levels as needed.
 
-        :param principals:
+        :param principals: list of principals to grant access to this resource id
         :return:
         """
         ops = []
@@ -577,10 +577,10 @@ class ResourceId(CloudNode):
 
     def check_access(self, principals: List[Type['Principal']]) -> Union[None, List[str]]:
         """
-        Given a list of Principals, return a List of access levels given to those Principals
+        Given a list of principals, return a list of access levels to this resource id for each principal
 
         :param principals:
-        :return:
+        :return: list of access levels to this resource id, one for each principal
         """
         ops = []
         for principal in principals:

--- a/fusillade/directory/resource.py
+++ b/fusillade/directory/resource.py
@@ -535,7 +535,8 @@ class ResourceId(CloudNode):
 
     def modify_principals(self, principals: List[Dict[str, str]]) -> None:
         """
-        Modify a list of principals to grant them access to this resource id by adding, updating or deleting access levels as needed.
+        Modify a list of principals to grant them access to this resource id by adding, updating or deleting access
+        levels as needed.
 
         :param principals: list of principals to grant access to this resource id
         :return:
@@ -558,7 +559,7 @@ class ResourceId(CloudNode):
             for modifications, r in zip(modifications, self.cd.batch_read(ops)['Responses']):
                 if r.get('SuccessfulResponse'):
                     current_ap = r['SuccessfulResponse']['GetLinkAttributes']['Attributes'][0]['Value'].popitem()[1]
-                    if modifications[1] == current_ap: # Pass
+                    if modifications[1] == current_ap:  # Pass
                         # If the old access level of the principal is equal to the new access level, then do nothing.
                         continue
                     elif modifications[1] is None:  # delete

--- a/fusillade/directory/resource.py
+++ b/fusillade/directory/resource.py
@@ -417,7 +417,7 @@ class ResourceId(CloudNode):
 
         :param next_token:
         :param per_page:
-        :return:
+        :return: JSON-formatted list of principals and a token for pagination
         """
         # retrieve the raw list of object references from cloud directory
         _results, next_token = self.cd.list_incoming_typed_links(self.object_ref, [], 'access_link',

--- a/fusillade/directory_schema.json
+++ b/fusillade/directory_schema.json
@@ -128,9 +128,27 @@
           "attributeDefinition": {
             "attributeType": "STRING",
             "isImmutable": true,
-            "attributeRules": {}
+            "attributeRules": {
+            }
           },
           "requiredBehavior": "REQUIRED_ALWAYS"
+        },
+        "source": {
+          "attributeDefinition": {
+            "attributeType": "STRING",
+            "isImmutable": false,
+            "attributeRules": {
+            }
+          },
+          "requiredBehavior": "NOT_REQUIRED"
+        },
+        "target": {
+          "attributeDefinition": {
+            "attributeType": "STRING",
+            "isImmutable": false,
+            "attributeRules": {}
+          },
+          "requiredBehavior": "NOT_REQUIRED"
         }
       },
       "identityAttributeOrder": [
@@ -179,6 +197,14 @@
             "attributeRules": {}
           },
           "requiredBehavior": "REQUIRED_ALWAYS"
+        },
+        "access_level": {
+          "attributeDefinition": {
+            "attributeType": "STRING",
+            "isImmutable": false,
+            "attributeRules": {}
+          },
+          "requiredBehavior": "NOT_REQUIRED"
         }
       },
       "identityAttributeOrder": [

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,17 +1,17 @@
 import json
 import os
-import time
 import typing
 
 import jwt
-from dcplib.aws import clients
+import time
 
-from fusillade.directory import publish_schema, create_directory
+from dcplib.aws import clients
 from fusillade import CloudDirectory
 from fusillade.config import Config
+from fusillade.directory import publish_schema, create_directory
 from tests import schema_name, random_hex_string
 
-test_account_file=f"{os.environ['FUS_HOME']}/test_accounts_{os.environ['FUS_DEPLOYMENT_STAGE']}.json"
+test_account_file = f"{os.environ['FUS_HOME']}/test_accounts_{os.environ['FUS_DEPLOYMENT_STAGE']}.json"
 try:
     with open(test_account_file, 'r') as fh:
         service_accounts = json.load(fh)
@@ -34,16 +34,21 @@ def normalize_json(src: typing.Union[str, dict]):
     return json.dumps(src, sort_keys=True)
 
 
-def create_test_IAMPolicy(name: str, actions: typing.List[str] = None) -> dict:
+def create_test_IAMPolicy(name: str, actions: typing.List[str] = None,
+                          resource_type: str = 'project',
+                          effect='Deny'
+                          ) -> dict:
     """Assists with the creation of policy statements for testing"""
+    if effect not in ['Deny', 'Allow']:
+        effect = 'Deny'
     statement = {
         "Version": "2012-10-17",
         "Statement": [
             {
                 "Sid": "DefaultRole",
-                "Effect": "Deny",
+                "Effect": effect,
                 "Action": actions if actions else ["fake:action"],
-                "Resource": "fake:resource"
+                "Resource": f"arn:dcp:fus:us-east-1:dev:{resource_type}/*"
             }
         ]
     }
@@ -52,17 +57,21 @@ def create_test_IAMPolicy(name: str, actions: typing.List[str] = None) -> dict:
     return statement
 
 
-def create_test_ResourcePolicy(name: str, actions: typing.List[str] = None) -> dict:
+def create_test_ResourcePolicy(name: str, actions: typing.List[str] = None,
+                               resource_type: str = 'project',
+                               effect='Deny') -> dict:
     """Assists with the creation of policy statements for testing"""
+    if effect not in ['Deny', 'Allow']:
+        effect = 'Deny'
     statement = {
         "Version": "2012-10-17",
         "Statement": [
             {
                 "Principal": "*",
                 "Sid": "DefaultRole",
-                "Effect": "Deny",
+                "Effect": effect,
                 "Action": actions if actions else ["fake:action"],
-                "Resource": "arn:dcp:fus:us-east-1:dev:project/*"
+                "Resource": f"arn:dcp:fus:us-east-1:dev:{resource_type}/*"
             }
         ]
     }

--- a/tests/test_evaluate_api.py
+++ b/tests/test_evaluate_api.py
@@ -83,13 +83,14 @@ class TestEvaluateApi(BaseAPITest, unittest.TestCase):
         group = 'user_default'
 
         # create a resource type
-        self.app.post(
+        resp = self.app.post(
             f'/v1/resource/{resource_type}',
             data=json.dumps({'actions': actions}),
             headers=admin_headers)
+        self.assertEqual(resp.status_code, 201)
 
         # create a resource policy read
-        self.app.post(
+        resp = self.app.post(
             f"/v1/resource/{resource_type}/policy/read",
             data=json.dumps({'policy': create_test_ResourcePolicy(
                 'read',
@@ -99,9 +100,10 @@ class TestEvaluateApi(BaseAPITest, unittest.TestCase):
             )}),
             headers=admin_headers
         )
+        self.assertEqual(resp.status_code, 201)
 
         # create a resource policy rw
-        self.app.post(
+        resp = self.app.post(
             f"/v1/resource/{resource_type}/policy/rw",
             data=json.dumps({
                 'policy': create_test_ResourcePolicy(
@@ -113,6 +115,7 @@ class TestEvaluateApi(BaseAPITest, unittest.TestCase):
             ),
             headers=admin_headers
         )
+        self.assertEqual(resp.status_code, 201)
 
         # create a resource id
         resp = self.app.post(

--- a/tests/test_evaluate_api.py
+++ b/tests/test_evaluate_api.py
@@ -10,7 +10,10 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from tests import eventually
 from tests.base_api_test import BaseAPITest
-from tests.common import get_auth_header, service_accounts
+from tests.common import get_auth_header, service_accounts, create_test_ResourcePolicy, create_test_IAMPolicy
+
+admin_headers = {'Content-Type': "application/json"}
+admin_headers.update(get_auth_header(service_accounts['admin']))
 
 
 class TestEvaluateApi(BaseAPITest, unittest.TestCase):
@@ -70,6 +73,209 @@ class TestEvaluateApi(BaseAPITest, unittest.TestCase):
             self.assertEqual(200, resp.status_code)
             self.assertEqual(False, json.loads(resp.body)['result'], msg=json.loads(resp.body))
 
+    def test_evaluate_resource_policy(self):
+        resource_type = 'evaluate_test_type'
+        actions = sorted(['rt:read', 'rt:write', 'rt:delete'])
+        resource_id = 'protected-data'
+        arn_prefix = "arn:dcp:fus:us-east-1:dev:"
+        resource_arn = f'{arn_prefix}{resource_type}/{resource_id}'
+        user = 'user_test_access_levels'
+        group = 'user_default'
+
+        # create a resource type
+        self.app.post(
+            f'/v1/resource/{resource_type}',
+            data=json.dumps({'actions': actions}),
+            headers=admin_headers)
+
+        # create a resource policy read
+        self.app.post(
+            f"/v1/resource/{resource_type}/policy/read",
+            data=json.dumps({'policy': create_test_ResourcePolicy(
+                'read',
+                actions=['rt:read'],
+                resource_type=resource_type,
+                effect='Allow'
+            )}),
+            headers=admin_headers
+        )
+
+        # create a resource policy rw
+        self.app.post(
+            f"/v1/resource/{resource_type}/policy/rw",
+            data=json.dumps({
+                'policy': create_test_ResourcePolicy(
+                    'rw',
+                    actions=['rt:read', 'rt:write', 'rt:delete'],
+                    resource_type=resource_type,
+                    effect='Allow'
+                )},
+            ),
+            headers=admin_headers
+        )
+
+        # create a resource id
+        resp = self.app.post(
+            f'/v1/resource/{resource_type}/id/{resource_id}',
+            headers=admin_headers)
+        self.assertEqual(resp.status_code, 201)
+
+        # create a role with read
+        resp = self.app.post(
+            f'/v1/role',
+            data=json.dumps(
+                {'role_id': 'read',
+                 'policy': create_test_IAMPolicy(
+                     'read',
+                     actions=['rt:read'],
+                     resource_type=resource_type,
+                     effect='Allow'
+                 )}),
+            headers=admin_headers
+        )
+        self.assertEqual(resp.status_code, 201)
+
+        # create a role with rw
+        resp = self.app.post(
+            f'/v1/role',
+            data=json.dumps(
+                {'role_id': 'rw',
+                 'policy': create_test_IAMPolicy(
+                     'rw',
+                     actions=['rt:read', 'rt:write', 'rt:delete'],
+                     resource_type=resource_type,
+                     effect='Allow'
+                 )}),
+            headers=admin_headers
+        )
+        self.assertEqual(resp.status_code, 201)
+
+        # create a user
+        resp = self.app.post(
+            f'/v1/user',
+            data=json.dumps({'user_id': user}),
+            headers=admin_headers)
+        self.assertEqual(resp.status_code, 201)
+
+        # user fails to read resource
+        resp = self.app.post(
+            '/v1/policies/evaluate',
+            headers=admin_headers,
+            data=json.dumps(
+                {'principal': user,
+                 'action': ['rt:read'],
+                 'resource': [resource_arn]}
+            )
+        )
+        self.assertFalse(json.loads(resp.body)['result'])
+
+        # give the user role read
+        resp = self.app.put(
+            f'/v1/user/{user}/roles?action=add',
+            headers=admin_headers,
+            data=json.dumps(
+                {'roles': ['read']}
+            )
+
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        # user fails to read resource
+        resp = self.app.post(
+            '/v1/policies/evaluate',
+            headers=admin_headers,
+            data=json.dumps(
+                {'principal': user,
+                 'action': ['rt:read'],
+                 'resource': [resource_arn]}
+            )
+        )
+        self.assertFalse(json.loads(resp.body)['result'])
+
+        # give the user access level read
+        request_body = [
+            {'member': user,
+             'member_type': 'user',
+             'access_level': 'read'}
+        ]
+        resp = self.app.put(
+            f'/v1/resource/{resource_type}/id/{resource_id}/members',
+            data=json.dumps(request_body),
+            headers=admin_headers
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        # the user has read access to resource
+        resp = self.app.post(
+            '/v1/policies/evaluate',
+            headers=admin_headers,
+            data=json.dumps(
+                {'principal': user,
+                 'action': ['rt:read'],
+                 'resource': [resource_arn]}
+            )
+        )
+        self.assertTrue(json.loads(resp.body)['result'])
+
+        # the user does not have write access to resource
+        resp = self.app.post(
+            '/v1/policies/evaluate',
+            headers=admin_headers,
+            data=json.dumps(
+                {'principal': user,
+                 'action': ['rt:write'],
+                 'resource': [resource_arn]}
+            )
+        )
+        self.assertFalse(json.loads(resp.body)['result'])
+
+        # give the user_default group rw access to the resource
+        request_body = [
+            {'member': group,
+             'member_type': 'group',
+             'access_level': 'rw'}
+        ]
+        resp = self.app.put(
+            f'/v1/resource/{resource_type}/id/{resource_id}/members',
+            data=json.dumps(request_body),
+            headers=admin_headers
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        # the user does not have write access to resource
+        resp = self.app.post(
+            '/v1/policies/evaluate',
+            headers=admin_headers,
+            data=json.dumps(
+                {'principal': user,
+                 'action': ['rt:write'],
+                 'resource': [resource_arn]}
+            )
+        )
+        self.assertFalse(json.loads(resp.body)['result'])
+
+        # give the group role rw
+        resp = self.app.put(
+            f'/v1/group/{group}/roles?action=add',
+            headers=admin_headers,
+            data=json.dumps(
+                {'roles': ['rw']}
+            )
+
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        # the user does have write access to resource
+        resp = self.app.post(
+            '/v1/policies/evaluate',
+            headers=admin_headers,
+            data=json.dumps(
+                {'principal': user,
+                 'action': ['rt:write'],
+                 'resource': [resource_arn]}
+            )
+        )
+        self.assertTrue(json.loads(resp.body)['result'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_resource_api.py
+++ b/tests/test_resource_api.py
@@ -392,7 +392,7 @@ class TestResourceIdApi(BaseAPITest, AssertJSONMixin, unittest.TestCase):
             )
             self.assertEqual(resp.status_code, 200)
 
-            # Check that the user has access by list who has access
+            # Check that the user has access by listing who has access
             resp = self.app.get(
                 f'/v1/resource/{self.test_resource}/id/{resource_id}/members',
                 headers=admin_headers)
@@ -439,7 +439,7 @@ class TestResourceIdApi(BaseAPITest, AssertJSONMixin, unittest.TestCase):
             )
             self.assertEqual(resp.status_code, 200)
 
-            # Check that the group has access by list who has access
+            # Check that the group has access by listing who has access
             resp = self.app.get(
                 f'/v1/resource/{self.test_resource}/id/{resource_id}/members',
                 headers=admin_headers)


### PR DESCRIPTION
User and groups can be given access to Resources through resource policies.

- Adding tests to evaluate access with IAM and resource policies
- Adding tests to add and remove resource access from users and groups
- Adding API to list members who have access to a resource
- Adding API to modify a member's access to a resource

The most complicated areas are the two new functions `list_principals` and `modify_principals`.
 