### PR TITLE
Merge RBAC branch into master

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -241,20 +241,21 @@ For resource, set the `partition` to `hca`, set your `service` name to the name 
 A new `resource_type` is created by providing the name of the `resource_type`, and the actions that can be performed on it. 
  Once a `resource_type` is created you can store `resource_id`s of that `resource_type` to apply ACLs.
  
-An `access_policy` is a policy associated with a `resource_type` and is used to define the different access levels 
+An `resource_policy` refers to a policy associated with a `resource_type` and is used to define different access levels 
  between principals and `resource_id`s. A principal may have only one level of access to a `resource_id`. All 
- `resource_id`s use the same pool of access policies for that particular `resource_type`. This mean that modifying an `access_policy`, 
- modifies it for all principals with that access level to a `resource_id`. New access policies can be defined for a 
- `resource_type` after the `resource_type` has been created. Deleting an `access_policy` removes access for all principals 
- with that level of access between a `resource_id`.
- Access policies can only define policies that use actions supported by that `resource_type`. 
- Actions can be added and removed after a `resource_type` has been created.
+ `resource_id`s use the same pool of resource policies for that particular `resource_type`. This mean that modifying an
+ `resource_policy`, modifies it for all principals with that access level to a `resource_id`. New `resource_policy` can
+  be 
+ defined for a `resource_type` after the `resource_type` has been created. Deleting an `resource_policy` removes access 
+ for all principals with that level of access between a `resource_id`. `resource_policy` can only define policies that 
+ use actions supported by that `resource_type`. Actions can be added and removed after a `resource_type` has been 
+ created.
  
 The creator of a `resource_id` is automatically designated as the owner of the resource. The owner of a
  `resource_id` can add additional owners, and assign access levels to principals for that `resource_id`. A principal only 
  has access to resource they are give access to, either directly or through group membership.
 
-If a `resource_type` is deleted, all access policies and 
+If a `resource_type` is deleted, all `resource_policy` and 
  `resource_id`s associated with that type are deleted.
  
 # Using Fusillade as a library

--- a/Readme.md
+++ b/Readme.md
@@ -241,12 +241,12 @@ For resource, set the `partition` to `hca`, set your `service` name to the name 
 A new `resource_type` is created by providing the name of the `resource_type`, and the actions that can be performed on it. 
  Once a `resource_type` is created you can store `resource_id`s of that `resource_type` to apply ACLs.
  
-An `resource_policy` refers to a policy associated with a `resource_type` and is used to define different access levels 
+A `resource_policy` refers to a policy associated with a `resource_type` and is used to define different access levels 
  between principals and `resource_id`s. A principal may have only one level of access to a `resource_id`. All 
- `resource_id`s use the same pool of resource policies for that particular `resource_type`. This mean that modifying an
+ `resource_id`s use the same pool of resource policies for that particular `resource_type`. This mean that modifying a
  `resource_policy`, modifies it for all principals with that access level to a `resource_id`. New `resource_policy` can
   be 
- defined for a `resource_type` after the `resource_type` has been created. Deleting an `resource_policy` removes access 
+ defined for a `resource_type` after the `resource_type` has been created. Deleting a `resource_policy` removes access 
  for all principals with that level of access between a `resource_id`. `resource_policy` can only define policies that 
  use actions supported by that `resource_type`. Actions can be added and removed after a `resource_type` has been 
  created.

--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -291,8 +291,11 @@ paths:
                 resource:
                   description: The resource the principal will perform the action against.
                   type: array
+                  maxItems: 1
+                  minItems: 1
                   items:
                     type: string
+                    pattern: 'arn:([\w\-\*]+:){2,4}[\w\-\*/]+'
       responses:
         200:
           description: The result of the policy evaluation.

--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -287,7 +287,7 @@ paths:
                   description: The action the principal is attempting to perform.
                   type: array
                   items:
-                    type: string
+                    $ref: '#/components/schemas/policy_action'
                 resource:
                   description: The resource the principal will perform the action against.
                   type: array
@@ -1003,7 +1003,7 @@ paths:
                 actions:
                   type: array
                   items:
-                    type: string
+                    $ref: '#/components/schemas/policy_action'
       responses:
         201:
           description: The new resource type has been created.
@@ -1058,7 +1058,7 @@ paths:
                   actions:
                     type: array
                     items:
-                      $ref: '#/components/schemas/resource_action'
+                      $ref: '#/components/schemas/policy_action'
         401:
           $ref: '#/components/responses/401'
         403:
@@ -1086,7 +1086,7 @@ paths:
                 actions:
                   type: array
                   items:
-                    $ref: '#/components/schemas/resource_action'
+                    $ref: '#/components/schemas/policy_action'
       responses:
         200:
           description: OK
@@ -1119,7 +1119,7 @@ paths:
                 actions:
                   type: array
                   items:
-                    $ref: '#/components/schemas/resource_action'
+                    $ref: '#/components/schemas/policy_action'
       responses:
         200:
           description: OK
@@ -1368,7 +1368,7 @@ components:
       properties:
         resources:
           $ref: '#/components/schemas/paged_results'
-    resource_action:
+    policy_action:
       type: string
       pattern: '[A-z]\w*[^\W_]:[A-z]\w*[^\W_]'
     policy_document:

--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -1282,6 +1282,99 @@ paths:
           $ref: '#/components/responses/404'
         default:
           description: Unexpected error.
+  /v1/resource/{resource_type_name}/id:
+    get:
+      summary: List ids of all resources matching the specified resource type.
+      description: List ids of all resources matching the specified resource type.
+      operationId: fusillade.api.resource.resource_type_name.id.get
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+        - $ref: '#/components/parameters/next_token'
+        - $ref: '#/components/parameters/per_page'
+      responses:
+        200:
+          $ref: '#/components/responses/200_paged'
+        206:
+          $ref: '#/components/responses/206'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        default:
+          description: Unexpected error.
+      tags:
+        - resource
+  /v1/resource/{resource_type_name}/id/{resource_id}:
+    get:
+      summary: Check if a resource of type resource_type_name with id resource_id exist.
+      description: Check if a resource of type resource_type_name with id resource_id exist.
+      operationId: fusillade.api.resource.resource_type_name.id.resource_id.get
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+        - $ref: '#/components/parameters/resource_id'
+      responses:
+        200:
+          description: Resource was found.
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        409:
+          $ref: '#/components/responses/409'
+        default:
+          description: Unexpected error.
+      tags:
+        - resource
+    post:
+      summary: Create a new resource.
+      description: Create a new resource.
+      operationId: fusillade.api.resource.resource_type_name.id.resource_id.post
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+        - $ref: '#/components/parameters/resource_id'
+      responses:
+        200:
+          description: Resource was created.
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        409:
+          $ref: '#/components/responses/409'
+        default:
+          description: Unexpected error.
+      tags:
+        - resource
+    delete:
+      summary: Delete a resource.
+      description: Delete a resource.
+      operationId: fusillade.api.resource.resource_type_name.id.resource_id.delete
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+        - $ref: '#/components/parameters/resource_id'
+      responses:
+        200:
+          description: Resource was deleted.
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        default:
+          description: Unexpected error.
+      tags:
+        - resource
 components:
   parameters:
     user_id:
@@ -1317,6 +1410,13 @@ components:
       in: path
       required: true
       description: The name of a type of resources to which a resource policy can be applied.
+      schema:
+        $ref: '#/components/schemas/custom_identifier'
+    resource_id:
+      name: resource_id
+      in: path
+      required: true
+      description: The id of the resource.
       schema:
         $ref: '#/components/schemas/custom_identifier'
     action:
@@ -1368,6 +1468,14 @@ components:
       properties:
         resources:
           $ref: '#/components/schemas/paged_results'
+    resource_ids:
+      description: A list of resource ids from a resource type.
+      type: object
+      properties:
+        resource_ids:
+          $ref: '#/components/schemas/paged_results'
+        resource_type:
+          type: string
     policy_action:
       type: string
       pattern: '[A-z]\w*[^\W_]:[A-z]\w*[^\W_]'
@@ -1503,6 +1611,7 @@ components:
               - $ref: '#/components/schemas/users'
               - $ref: '#/components/schemas/resource_types'
               - $ref: '#/components/schemas/policies'
+              - $ref: '#/components/schemas/resource_ids'
     206:
       description: A single page of results was retrieved.
       headers:
@@ -1526,6 +1635,7 @@ components:
               - $ref: '#/components/schemas/users'
               - $ref: '#/components/schemas/resource_types'
               - $ref: '#/components/schemas/policies'
+              - $ref: '#/components/schemas/resource_ids'
     401:
       description: The users credentials failed to authenticate.
     403:

--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -1195,7 +1195,9 @@ paths:
           description: Unexpected error.
     post:
       summary: Add a new resource policy for the specified resource type.
-      description: Add a new resource policy. This makes the resource policy available for all resources of that type. Once added, the new resource policy can be applied to members by using PUT /v1/resource/{resource_type_name}/{resource_id}/policies/{policy_name}/members/{type}/{entity_id}.
+      description: Add a new resource policy. This makes the resource policy available for all resources of that type
+        . Once added, the new resource policy can be applied to members by using PUT
+        /v1/resource/{resource_type_name}/id/{resource_id}/members
       operationId: fusillade.api.resource.resource_type_name.policy.policy_name.post
       security:
         - BearerAuth: []

--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -1380,6 +1380,61 @@ paths:
           description: Unexpected error.
       tags:
         - resource
+  /v1/resource/{resource_type_name}/id/{resource_id}/members:
+    get:
+      summary: List all members that have access to this resource.
+      description: List all members that have access to this resource. Members include users, and groups with any
+        level of access to this resource.
+      operationId: fusillade.api.resource.resource_type_name.id.resource_id.members.get
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+        - $ref: '#/components/parameters/resource_id'
+        - $ref: '#/components/parameters/next_token'
+        - $ref: '#/components/parameters/per_page'
+      responses:
+        200:
+          $ref: '#/components/responses/200_paged'
+        206:
+          $ref: '#/components/responses/206'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+    put:
+      summary: Give a principal access defined by a {resource_policy} to {resource_type_name}/{resource_id}.
+      description:  Give a principal access defined by {policy_name} to {resource_type_name}/{resource_id}.
+      operationId: fusillade.api.resource.resource_type_name.id.resource_id.members.put
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+        - $ref: '#/components/parameters/resource_id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/resource_member'
+              maxItems: 1
+              minItems: 1
+      responses:
+        200:
+          description: The {type}/{entity_id} has been added to the policy.
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        default:
+          description: Unexpected error.
+      tags:
+        - resource
 components:
   parameters:
     user_id:
@@ -1460,6 +1515,9 @@ components:
       schema:
         type: string
   schemas:
+    principal_type:
+        type: string
+        enum: [user, group]
     paged_results:
       type: array
       items:
@@ -1481,9 +1539,38 @@ components:
           $ref: '#/components/schemas/paged_results'
         resource_type:
           type: string
+    resource_member:
+      type: object
+      properties:
+        member:
+          type: string
+        member_type:
+          $ref: '#/components/schemas/principal_type'
+        access_level:
+          type: string
+      required:
+        - member
+        - member_type
+      example:
+        Add or update access:
+          value:
+            member: i_am_a_user_name
+            member_type: user
+            access_level: read
+        Remove access:
+          value:
+            member: i_am_a_user_name
+            member_type: user
     policy_action:
       type: string
       pattern: '[A-z]\w*[^\W_]:[A-z]\w*[^\W_]'
+    members:
+      type: object
+      properties:
+        members:
+          type: array
+          items:
+            $ref: '#/components/schemas/resource_member'
     policy_document:
       description: A resource policy, used for controlling access to a resource.
       type: object
@@ -1614,6 +1701,7 @@ components:
               - $ref: '#/components/schemas/groups'
               - $ref: '#/components/schemas/roles'
               - $ref: '#/components/schemas/users'
+              - $ref: '#/components/schemas/members'
               - $ref: '#/components/schemas/resource_types'
               - $ref: '#/components/schemas/policies'
               - $ref: '#/components/schemas/resource_ids'
@@ -1638,6 +1726,7 @@ components:
               - $ref: '#/components/schemas/groups'
               - $ref: '#/components/schemas/roles'
               - $ref: '#/components/schemas/users'
+              - $ref: '#/components/schemas/members'
               - $ref: '#/components/schemas/resource_types'
               - $ref: '#/components/schemas/policies'
               - $ref: '#/components/schemas/resource_ids'

--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -999,7 +999,7 @@ paths:
               type: object
               properties:
                 owner_policy:
-                  $ref: '#/components/schemas/resource_policy'
+                  $ref: '#/components/schemas/policy_document'
                 actions:
                   type: array
                   items:
@@ -1038,6 +1038,250 @@ paths:
           description: Unexpected error.
       tags:
         - resource
+  /v1/resource/{resource_type_name}/actions:
+    get:
+      summary: List all actions for this resource type.
+      description: List all actions for this resource type.
+      operationId: fusillade.api.resource.resource_type_name.actions.get
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  actions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/resource_action'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        default:
+          description: Unexpected error.
+      tags:
+        - resource
+    put:
+      summary: Add a new action for a resource type.
+      description: Add a new action for a resource type.
+      operationId: fusillade.api.resource.resource_type_name.actions.put
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                actions:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/resource_action'
+      responses:
+        200:
+          description: OK
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        409:
+          $ref: '#/components/responses/409'
+        default:
+          description: Unexpected error.
+      tags:
+        - resource
+    delete:
+      summary: Delete an existing action for a resource type.
+      description: Delete an existing action for a resource type.
+      operationId: fusillade.api.resource.resource_type_name.actions.delete
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                actions:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/resource_action'
+      responses:
+        200:
+          description: OK
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        409:
+          $ref: '#/components/responses/409'
+        default:
+          description: Unexpected error.
+      tags:
+        - resource
+  /v1/resource/{resource_type_name}/policy:
+    get:
+      summary: List the available policies for this resource type.
+      description: List the available policies for this resource type.
+      operationId: fusillade.api.resource.resource_type_name.policy.get
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+        - $ref: '#/components/parameters/next_token'
+        - $ref: '#/components/parameters/per_page'
+      responses:
+        200:
+          $ref: '#/components/responses/200_paged'
+        206:
+          $ref: '#/components/responses/206'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        default:
+          description: Unexpected error.
+      tags:
+        - resource
+  /v1/resource/{resource_type_name}/policy/{policy_name}:
+    get:
+      summary: Retrieve information about resource policy
+      description: Retrieve information about resource policy.
+      operationId: fusillade.api.resource.resource_type_name.policy.policy_name.get
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+        - $ref: '#/components/parameters/policy_name'
+      tags:
+        - resource
+      responses:
+        200:
+          description: The {policy_name} policy for {resource_type_name} returned.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                    policy_document:
+                      $ref: '#/components/schemas/policy_document'
+                    policy_type:
+                      $ref: '#/components/schemas/policy_type'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        default:
+          description: Unexpected error.
+    post:
+      summary: Add a new resource policy for the specified resource type.
+      description: Add a new resource policy. This makes the resource policy available for all resources of that type. Once added, the new resource policy can be applied to members by using PUT /v1/resource/{resource_type_name}/{resource_id}/policies/{policy_name}/members/{type}/{entity_id}.
+      operationId: fusillade.api.resource.resource_type_name.policy.policy_name.post
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+        - $ref: '#/components/parameters/policy_name'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                policy:
+                  type: object
+                  properties:
+                    document:
+                      $ref: '#/components/schemas/policy_document'
+                    type:
+                      $ref: '#/components/schemas/policy_type'
+      tags:
+        - resource
+      responses:
+        200:
+          description: Created the {policy_name} policy for {resource_type_name}.
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        409:
+          $ref: '#/components/responses/409'
+        default:
+          description: Unexpected error.
+    put:
+      summary: Modify an existing resource policy for the specified resource type
+      description: Modify an existing resource policy. This will affect all members that use this resource policy to access a {resource_type_name}/{resource_ids}.
+      operationId: fusillade.api.resource.resource_type_name.policy.policy_name.put
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+        - $ref: '#/components/parameters/policy_name'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                policy:
+                  $ref: '#/components/schemas/policy_document'
+      responses:
+        200:
+          description: Modified the {policy_name} policy for {resource_type_name}.
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        default:
+          description: Unexpected error.
+      tags:
+        - resource
+    delete:
+      summary: Delete an existing resource policy for the specified resource type.
+      description: Delete an existing resource policy. This will affect all members that use this resource policy to access a {resource_type_name}/{resource_ids}.
+      operationId: fusillade.api.resource.resource_type_name.policy.policy_name.delete
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+        - $ref: '#/components/parameters/policy_name'
+      tags:
+        - resource
+      responses:
+        200:
+          description: Deleted the {policy_name} policy for {resource_type_name}.
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        default:
+          description: Unexpected error.
 components:
   parameters:
     user_id:
@@ -1075,13 +1319,6 @@ components:
       description: The name of a type of resources to which a resource policy can be applied.
       schema:
         $ref: '#/components/schemas/custom_identifier'
-    resource_action:
-      name: action
-      in: path
-      required: true
-      schema:
-        type: string
-        pattern: '[A-z]\w*[^\W_]:[A-z]\w*[^\W_]'
     action:
       name: action
       in: query
@@ -1122,13 +1359,19 @@ components:
       type: array
       items:
         type: string
+    policy_type:
+      type: string
+      enum: ['ResourcePolicy', 'IAMPolicy']
     resource_types:
       description: A list of resource types.
       type: object
       properties:
         resources:
           $ref: '#/components/schemas/paged_results'
-    resource_policy:
+    resource_action:
+      type: string
+      pattern: '[A-z]\w*[^\W_]:[A-z]\w*[^\W_]'
+    policy_document:
       description: A resource policy, used for controlling access to a resource.
       type: object
       properties:

--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -935,6 +935,109 @@ paths:
           description: Unexpected error.
       tags:
         - role
+  /v1/resource:
+    get:
+      summary:  List available resource types
+      description: List available resource types
+      operationId: fusillade.api.resource.get
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/next_token'
+        - $ref: '#/components/parameters/per_page'
+      responses:
+        200:
+          $ref: '#/components/responses/200_paged'
+        206:
+          $ref: '#/components/responses/206'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        default:
+          description: Unexpected error.
+      tags:
+        - resource
+  /v1/resource/{resource_type_name}:
+    get:
+      summary: List all resources for this resource type
+      description: List all resources for this resource type
+      operationId: fusillade.api.resource.resource_type_name.get
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+        - $ref: '#/components/parameters/next_token'
+        - $ref: '#/components/parameters/per_page'
+      responses:
+        200:
+          $ref: '#/components/responses/200_paged'
+        206:
+          $ref: '#/components/responses/206'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        default:
+          description: Unexpected error.
+      tags:
+        - resource
+    post:
+      summary: Create a new resource type.
+      description: Create a new resource type.
+      operationId: fusillade.api.resource.resource_type_name.post
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                owner_policy:
+                  $ref: '#/components/schemas/resource_policy'
+                actions:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        201:
+          description: The new resource type has been created.
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        409:
+          $ref: '#/components/responses/409'
+        default:
+          description: Unexpected error.
+      tags:
+        - resource
+    delete:
+      summary: Delete an existing resource type.
+      description: Delete an existing resource type if there are no ids of that resource type stored.
+      operationId: fusillade.api.resource.resource_type_name.delete
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/resource_type_name'
+      responses:
+        201:
+          description: The resource has been deleted.
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        409:
+          $ref: '#/components/responses/Resource_not_empty'
+        default:
+          description: Unexpected error.
+      tags:
+        - resource
 components:
   parameters:
     user_id:
@@ -965,6 +1068,20 @@ components:
       schema:
         type: string
         enum: [group, role]
+    resource_type_name:
+      name: resource_type_name
+      in: path
+      required: true
+      description: The name of a type of resources to which a resource policy can be applied.
+      schema:
+        $ref: '#/components/schemas/custom_identifier'
+    resource_action:
+      name: action
+      in: path
+      required: true
+      schema:
+        type: string
+        pattern: '[A-z]\w*[^\W_]:[A-z]\w*[^\W_]'
     action:
       name: action
       in: query
@@ -994,11 +1111,54 @@ components:
         minimum: 5
         maximum: 30
         default: 15
+    policy_name:
+      name: policy_name
+      in: path
+      required: true
+      schema:
+        type: string
   schemas:
     paged_results:
       type: array
       items:
         type: string
+    resource_types:
+      description: A list of resource types.
+      type: object
+      properties:
+        resources:
+          $ref: '#/components/schemas/paged_results'
+    resource_policy:
+      description: A resource policy, used for controlling access to a resource.
+      type: object
+      properties:
+        Statements:
+          type: array
+          items:
+            type: object
+            properties:
+              Sid:
+                type: string
+              Effect:
+                type: string
+                enum: ['Allow', 'Deny']
+              Actions:
+                type: array
+                items:
+                  type: string
+              Resource:
+                type: array
+                items:
+                  type: string
+    policy:
+      type: object
+      properties:
+        policy:
+          type: string
+    policies:
+      type: array
+      items:
+        type: object
     groups:
       type: object
       properties:
@@ -1089,6 +1249,17 @@ components:
                         type: array
                         items:
                           type: string
+    200_paged:
+      description: All results have been retrieved.
+      content:
+        application/json:
+          schema:
+            anyOf:
+              - $ref: '#/components/schemas/groups'
+              - $ref: '#/components/schemas/roles'
+              - $ref: '#/components/schemas/users'
+              - $ref: '#/components/schemas/resource_types'
+              - $ref: '#/components/schemas/policies'
     206:
       description: A single page of results was retrieved.
       headers:
@@ -1110,6 +1281,8 @@ components:
               - $ref: '#/components/schemas/groups'
               - $ref: '#/components/schemas/roles'
               - $ref: '#/components/schemas/users'
+              - $ref: '#/components/schemas/resource_types'
+              - $ref: '#/components/schemas/policies'
     401:
       description: The users credentials failed to authenticate.
     403:
@@ -1119,6 +1292,8 @@ components:
       description: Resource not found.
     409:
       description: The object already exists.
+    Resource_not_empty:
+      description: All resource ids must be deleted before the resource type can be deleted.
   securitySchemes:
     BearerAuth:
       type: http

--- a/fusillade/api/evaluate.py
+++ b/fusillade/api/evaluate.py
@@ -23,7 +23,7 @@ def evaluate_policy_api(token_info, body):  # TODO allow context variables to be
                 body['principal'],
                 body['action'],
                 body['resource'],
-                authz_params['policies'],
+                authz_params['IAMPolicy'],
                 context_entries=restricted_context_entries(authz_params))
     return make_response(jsonify(**response), 200)
 

--- a/fusillade/api/evaluate.py
+++ b/fusillade/api/evaluate.py
@@ -4,7 +4,7 @@ from threading import Thread
 
 from flask import make_response, jsonify
 
-from fusillade.directory import User
+from fusillade.directory.authorization import get_resource_authz_parameters
 from fusillade.errors import AuthorizationException
 from fusillade.utils.authorize import assert_authorized, evaluate_policy, restricted_context_entries, get_email_claim
 
@@ -15,7 +15,7 @@ def evaluate_policy_api(token_info, body):  # TODO allow context variables to be
                          ['fus:Evaluate'],
                          ['arn:hca:fus:*:*:user']):
         try:
-            authz_params = User(body['principal']).get_authz_params()
+            authz_params = get_resource_authz_parameters(body['principal'], body['resource'])
         except AuthorizationException:
             response = {'result': False, 'reason': "The user is disabled."}
         else:
@@ -24,6 +24,7 @@ def evaluate_policy_api(token_info, body):  # TODO allow context variables to be
                 body['action'],
                 body['resource'],
                 authz_params['IAMPolicy'],
+                authz_params.get('ResourcePolicy'),
                 context_entries=restricted_context_entries(authz_params))
     return make_response(jsonify(**response), 200)
 

--- a/fusillade/api/evaluate.py
+++ b/fusillade/api/evaluate.py
@@ -5,7 +5,7 @@ from threading import Thread
 from flask import make_response, jsonify
 
 from fusillade.directory.authorization import get_resource_authz_parameters
-from fusillade.errors import AuthorizationException
+from fusillade.errors import AuthorizationException, ResourceNotFound
 from fusillade.utils.authorize import assert_authorized, evaluate_policy, restricted_context_entries, get_email_claim
 
 
@@ -17,7 +17,9 @@ def evaluate_policy_api(token_info, body):  # TODO allow context variables to be
         try:
             authz_params = get_resource_authz_parameters(body['principal'], body['resource'])
         except AuthorizationException:
-            response = {'result': False, 'reason': "The user is disabled."}
+            response = {'result': False, 'reason': "UserDisabled"}
+        except ResourceNotFound as ex:
+            response = {'result': False, 'reason': ex.reason, 'details': 'The requested resource does not exist.'}
         else:
             response = evaluate_policy(
                 body['principal'],

--- a/fusillade/api/resource/__init__.py
+++ b/fusillade/api/resource/__init__.py
@@ -1,0 +1,11 @@
+from flask import request
+
+from fusillade.api.paging import get_next_token, get_page
+from fusillade.directory.resource import ResourceType
+from fusillade.utils.authorize import authorize
+
+
+@authorize(["fus:GetResources"], ["arn:hca:fus:*:*:resource/*"])
+def get(token_info: dict):
+    next_token, per_page = get_next_token(request.args)
+    return get_page(ResourceType.list_all, next_token, per_page, content_key='resources')

--- a/fusillade/api/resource/resource_type_name/__init__.py
+++ b/fusillade/api/resource/resource_type_name/__init__.py
@@ -1,0 +1,42 @@
+from flask import request, make_response, jsonify
+
+from fusillade.directory.resource import ResourceType
+from fusillade.utils.authorize import authorize
+
+
+@authorize(["fus:GetResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}"],
+           resource_params=['resource_type_name'])
+def get(token_info: dict, resource_type_name):
+    rt = ResourceType(resource_type_name)
+    rt._exists([rt.name])
+    info = rt.get_info()
+    return make_response(info, 200)
+
+
+@authorize(["fus:PostResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}"],
+           resource_params=['resource_type_name'])
+def post(token_info: dict, resource_type_name):
+    json_body = request.json
+    rt = ResourceType.create(resource_type_name, json_body['actions'])
+    return make_response(f"New resource type {rt.name} created.", 201)
+
+
+@authorize(["fus:DeleteResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}"],
+           resource_params=['resource_type_name'])
+def delete(token_info: dict, resource_type_name):
+    rt = ResourceType(resource_type_name)
+    rids = rt.list_ids()[0]
+    if len(rids) > 0:
+        # TODO write tests for this once create resource_id API is complete
+        return make_response(jsonify(
+            {'msg': 'All resource ids must be deleted before the resource type can be deleted.',
+             'resource_ids': rids}), 409)
+    rt.delete_node()
+    return make_response(jsonify({
+        'msg': "Resource type deleted.",
+        'resource_type': rt.name}),
+        200
+    )

--- a/fusillade/api/resource/resource_type_name/__init__.py
+++ b/fusillade/api/resource/resource_type_name/__init__.py
@@ -28,7 +28,7 @@ def post(token_info: dict, resource_type_name):
            resource_params=['resource_type_name'])
 def delete(token_info: dict, resource_type_name):
     rt = ResourceType(resource_type_name)
-    rids = rt.list_ids()[0]
+    rids = rt.list_ids()[0]['resource_ids']
     if len(rids) > 0:
         # TODO write tests for this once create resource_id API is complete
         return make_response(jsonify(

--- a/fusillade/api/resource/resource_type_name/actions.py
+++ b/fusillade/api/resource/resource_type_name/actions.py
@@ -1,0 +1,33 @@
+from flask import request, make_response, jsonify
+
+from fusillade.directory.resource import ResourceType
+from fusillade.utils.authorize import authorize
+
+
+@authorize(["fus:GetResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}/action"],
+           resource_params=['resource_type_name'])
+def get(token_info: dict, resource_type_name):
+    rt = ResourceType(resource_type_name)
+    actions = rt.actions
+    return make_response(jsonify({'actions': actions}), 200)
+
+
+@authorize(["fus:PutResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}/action"],
+           resource_params=['resource_type_name'])
+def put(token_info: dict, resource_type_name):
+    json_body = request.json
+    rt = ResourceType(resource_type_name)
+    rt.add_actions(json_body['actions'])
+    return make_response(f"Actions added to resource type {rt.name}.", 200)
+
+
+@authorize(["fus:DeleteResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}/action"],
+           resource_params=['resource_type_name'])
+def delete(token_info: dict, resource_type_name):
+    json_body = request.json
+    rt = ResourceType(resource_type_name)
+    rt.remove_actions(json_body['actions'])
+    return make_response(f"Actions removed from resource type {rt.name}.", 200)

--- a/fusillade/api/resource/resource_type_name/id/__init__.py
+++ b/fusillade/api/resource/resource_type_name/id/__init__.py
@@ -1,0 +1,13 @@
+from flask import request
+
+from fusillade.api.paging import get_next_token, get_page
+from fusillade.directory.resource import ResourceType
+from fusillade.utils.authorize import authorize
+
+
+@authorize(["fus:GetResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}/id"],
+           resource_params=['resource_type_name'])
+def get(token_info: dict, resource_type_name):
+    next_token, per_page = get_next_token(request.args)
+    return get_page(ResourceType(resource_type_name).list_ids, next_token, per_page, content_key='resource_ids')

--- a/fusillade/api/resource/resource_type_name/id/resource_id/__init__.py
+++ b/fusillade/api/resource/resource_type_name/id/resource_id/__init__.py
@@ -1,0 +1,37 @@
+from flask import make_response, jsonify
+
+from fusillade.directory.resource import ResourceType, ResourceId
+from fusillade.utils.authorize import authorize
+
+
+@authorize(["fus:GetResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}/{resource_id}"],
+           resource_params=['resource_type_name', 'resource_id'])
+def get(token_info: dict, resource_type_name, resource_id):
+    rid = ResourceId(resource_type_name, resource_id)
+    info = rid.get_info()
+    return make_response(info, 200)
+
+
+@authorize(["fus:PostResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}/{resource_id}"],
+           resource_params=['resource_type_name', 'resource_id'])
+def post(token_info: dict, resource_type_name, resource_id):
+    rt = ResourceType(resource_type_name)
+    rt.create_id(resource_id)
+    return make_response(jsonify({
+        'msg': f"Created resource/{rt.name}/id/{resource_id}.",
+        'resource_type': rt.name,
+        'resource_id': resource_id}), 201)
+
+
+@authorize(["fus:DeleteResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}/{resource_id}"],
+           resource_params=['resource_type_name', 'resource_id'])
+def delete(token_info: dict, resource_type_name, resource_id):
+    rid = ResourceId(resource_type_name, name=resource_id)
+    rid.delete_node()
+    return make_response(jsonify({
+        'msg': f"Deleted resource/{rid.resource_type}/id/{resource_id}.",
+        'resource_type': rid.resource_type.name,
+        'resource_id': rid.name}), 200)

--- a/fusillade/api/resource/resource_type_name/id/resource_id/members/__init__.py
+++ b/fusillade/api/resource/resource_type_name/id/resource_id/members/__init__.py
@@ -1,0 +1,30 @@
+from flask import make_response, jsonify, request
+
+from fusillade.api.paging import get_page, get_next_token
+from fusillade.directory.resource import ResourceId
+from fusillade.utils.authorize import authorize
+
+
+@authorize(["fus:GetResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}/{resource_id}/members"],
+           resource_params=['resource_type_name', 'resource_id'])
+def get(token_info: dict, resource_type_name, resource_id):
+    next_token, per_page = get_next_token(request.args)
+    return get_page(
+        ResourceId(resource_type_name, resource_id).list_principals,
+        next_token,
+        per_page,
+        content_key='members')
+
+
+@authorize(["fus:PutResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}/{resource_id}/members"],
+           resource_params=['resource_type_name', 'resource_id'])
+def put(token_info: dict, resource_type_name, resource_id):
+    members = request.json
+    rt = ResourceId(resource_type_name, resource_id)
+    rt.modify_principals(members)
+    return make_response(jsonify({
+        'msg': f"Access levels modified.",
+        'resource_type': rt.name,
+        'resource_id': resource_id}), 200)

--- a/fusillade/api/resource/resource_type_name/policy/__init__.py
+++ b/fusillade/api/resource/resource_type_name/policy/__init__.py
@@ -1,0 +1,14 @@
+from flask import request
+
+from fusillade.api.paging import get_next_token, get_page
+from fusillade.directory.resource import ResourceType
+from fusillade.utils.authorize import authorize
+
+
+@authorize(["fus:GetResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}/policy"],
+           resource_params=['resource_type_name'])
+def get(token_info: dict, resource_type_name):
+    next_token, per_page = get_next_token(request.args)
+    rt = ResourceType(resource_type_name)
+    return get_page(rt.list_policies, next_token, per_page, content_key='policies')

--- a/fusillade/api/resource/resource_type_name/policy/policy_name/__init__.py
+++ b/fusillade/api/resource/resource_type_name/policy/policy_name/__init__.py
@@ -1,0 +1,45 @@
+import json
+
+from flask import request, make_response, jsonify
+
+from fusillade.directory.resource import ResourceType
+from fusillade.utils.authorize import authorize
+
+
+@authorize(["fus:GetResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}/policy/{policy_name}"],
+           resource_params=['resource_type_name', 'policy_name'])
+def get(token_info: dict, resource_type_name, policy_name):
+    rt = ResourceType(resource_type_name)
+    rt._exists([rt.name])
+    policy = rt.get_policy(policy_name)
+    return make_response(jsonify(policy), 200)
+
+
+@authorize(["fus:PostResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}/policy/{policy_name}"],
+           resource_params=['resource_type_name', 'policy_name'])
+def post(token_info: dict, resource_type_name, policy_name):
+    json_body = request.json
+    rt = ResourceType(resource_type_name)
+    rt.create_policy(policy_name, json_body['policy'], 'ResourcePolicy')
+    return make_response(f"Created resource/{resource_type_name}/policy/{policy_name}.", 201)
+
+
+@authorize(["fus:PutResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}/policy/{policy_name}"],
+           resource_params=['resource_type_name', 'policy_name'])
+def put(token_info: dict, resource_type_name, policy_name):
+    json_body = request.json
+    rt = ResourceType(resource_type_name)
+    rt.update_policy(policy_name, json_body['policy'], 'ResourcePolicy')
+    return make_response(f"Modified resource/{resource_type_name}/policy/{policy_name}.", 200)
+
+
+@authorize(["fus:DeleteResources"],
+           ["arn:hca:fus:*:*:resource/{resource_type_name}/policy/{policy_name}"],
+           resource_params=['resource_type_name', 'policy_name'])
+def delete(token_info: dict, resource_type_name, policy_name):
+    rt = ResourceType(resource_type_name)
+    rt.delete_policy(policy_name)
+    return make_response(f"Deleted resource/{resource_type_name}/policy/{policy_name}.", 200)

--- a/fusillade/directory/authorization.py
+++ b/fusillade/directory/authorization.py
@@ -4,7 +4,7 @@ from dcplib.aws.clients import clouddirectory as cd_client
 from fusillade import Config
 from fusillade.directory import User, Group
 from fusillade.directory.resource import ResourceId, ResourceType
-from fusillade.errors import FusilladeForbiddenException
+from fusillade.errors import ResourceNotFound
 from fusillade.policy.resource_policy import combine
 
 
@@ -32,7 +32,7 @@ def get_resource_authz_parameters(user: str, resources: Union[List[str], str]):
         r_id = ResourceId(r_type, r_id)
         resource_policies = r_id.check_access([_user] + [Group(g) for g in groups])
         if not resource_policies:
-            raise FusilladeForbiddenException()
+            raise ResourceNotFound("ResourceNotFound")
         policies.extend(resource_policies)
     policies.extend(list(_user.get_policy_ids()))
     authz_params = Config.get_directory().get_policies(policies)

--- a/fusillade/directory/authorization.py
+++ b/fusillade/directory/authorization.py
@@ -1,5 +1,6 @@
 from typing import List, Union
 
+from dcplib.aws.clients import clouddirectory as cd_client
 from fusillade import Config
 from fusillade.directory import User, Group
 from fusillade.directory.resource import ResourceId, ResourceType
@@ -18,12 +19,18 @@ def get_resource_authz_parameters(user: str, resources: Union[List[str], str]):
     """
     policies = []
     _user = User(user)
+    try:
+        groups = _user.groups
+    except cd_client.exceptions.ResourceNotFoundException:
+        _user = User.provision_user(user)
+        groups = _user.groups
+
     # Only support a single resource for now
     resource = resources[0] if isinstance(resources, list) else resources
     r_type, r_id, *_ = resource.split(':')[-1].split('/')
     if r_type in ResourceType.get_types():
         r_id = ResourceId(r_type, r_id)
-        resource_policies = r_id.check_access([_user] + [Group(g) for g in _user.groups])
+        resource_policies = r_id.check_access([_user] + [Group(g) for g in groups])
         if not resource_policies:
             raise FusilladeForbiddenException()
         policies.extend(resource_policies)

--- a/fusillade/directory/authorization.py
+++ b/fusillade/directory/authorization.py
@@ -30,7 +30,7 @@ def get_resource_authz_parameters(user: str, resources: Union[List[str], str]):
     r_type, r_id, *_ = resource.split(':')[-1].split('/')
     if r_type in ResourceType.get_types():
         r_id = ResourceId(r_type, r_id)
-        resource_policies = r_id.check_access([_user] + [Group(g) for g in groups])
+        resource_policies = r_id.check_access([_user] + [Group(object_ref=g) for g in groups])
         if not resource_policies:
             raise ResourceNotFound("ResourceNotFound")
         policies.extend(resource_policies)

--- a/fusillade/directory/authorization.py
+++ b/fusillade/directory/authorization.py
@@ -1,0 +1,34 @@
+from typing import List, Union
+
+from fusillade import Config
+from fusillade.directory import User, Group
+from fusillade.directory.resource import ResourceId, ResourceType
+from fusillade.errors import FusilladeForbiddenException
+from fusillade.policy.resource_policy import combine
+
+
+def get_resource_authz_parameters(user: str, resources: Union[List[str], str]):
+    """
+
+    Get all policy ids, and send them to lookup policy, group them by policy type.
+
+    :param user:
+    :param resource:
+    :return:
+    """
+    policies = []
+    _user = User(user)
+    # Only support a single resource for now
+    resource = resources[0] if isinstance(resources, list) else resources
+    r_type, r_id, *_ = resource.split(':')[-1].split('/')
+    if r_type in ResourceType.get_types():
+        r_id = ResourceId(r_type, r_id)
+        resource_policies = r_id.check_access([_user] + [Group(g) for g in _user.groups])
+        if not resource_policies:
+            raise FusilladeForbiddenException()
+        policies.extend(resource_policies)
+    policies.extend(list(_user.get_policy_ids()))
+    authz_params = Config.get_directory().get_policies(policies)
+    if authz_params.get('ResourcePolicy'):
+        authz_params['ResourcePolicy'] = combine([i['policy_document'] for i in authz_params.get('ResourcePolicy')])
+    return authz_params

--- a/fusillade/directory/clouddirectory.py
+++ b/fusillade/directory/clouddirectory.py
@@ -596,6 +596,20 @@ class CloudDirectory:
             }
         }
 
+    @batch_reference
+    def batch_get_link_attributes(self,
+                                  TypedLinkSpecifier: Dict[str, Any],
+                                  AttributeNames: List[str]) -> Dict[str, Any]:
+        """
+        A helper function to format a batch get_attributes operation
+        """
+        return {
+            'GetLinkAttributes': {
+                'TypedLinkSpecifier': TypedLinkSpecifier,
+                'AttributeNames': AttributeNames
+            }
+        }
+
     @staticmethod
     @batch_reference
     def batch_attach_object(parent: str, child: str, name: str) -> Dict[str, Any]:

--- a/fusillade/directory/clouddirectory.py
+++ b/fusillade/directory/clouddirectory.py
@@ -474,11 +474,11 @@ class CloudDirectory:
                 result[key] = attr['Value'][ValueTypes.StringValue.name]
             elif ValueTypes.BinaryValue.name in attr['Value'].keys():
                 result[key] = attr['Value'][ValueTypes.BinaryValue.name]
-            elif ValueTypes.BinaryValue.name in attr['Value'].keys():
+            elif ValueTypes.BooleanValue.name in attr['Value'].keys():
                 result[key] = attr['Value'][ValueTypes.BooleanValue.name]
-            elif ValueTypes.BinaryValue.name in attr['Value'].keys():
+            elif ValueTypes.NumberValue.name in attr['Value'].keys():
                 result[key] = attr['Value'][ValueTypes.NumberValue.name]
-            elif ValueTypes.BinaryValue.name in attr['Value'].keys():
+            elif ValueTypes.DatetimeValue.name in attr['Value'].keys():
                 result[key] = attr['Value'][ValueTypes.DatetimeValue.name]
         return result
 
@@ -811,7 +811,7 @@ class CloudDirectory:
 
     def get_policies(self, policy_ids: List[str]) -> Dict[str, Union[List[Dict[str, str]], List[str]]]:
         """
-        Get's policy statements and attributes.
+        Gets policy statements and attributes.
 
         :param policy_paths: a list of paths leading to policy nodes stored in cloud directory
         :param policy_type: the type of policies to retrieve from the policy nodes

--- a/fusillade/directory/clouddirectory.py
+++ b/fusillade/directory/clouddirectory.py
@@ -466,17 +466,20 @@ class CloudDirectory:
     @staticmethod
     def parse_attributes(attributes: List[Dict[str, Any]]) -> Dict[str, Any]:
         result = dict()
+        # check if we are parsing object attributes or typed link attributes
+        typed_link = attributes[0].get('Key') is None
         for attr in attributes:
+            key = attr['AttributeName'] if typed_link else attr['Key']['Name']
             if ValueTypes.StringValue.name in attr['Value'].keys():
-                result[attr['Key']['Name']] = attr['Value'][ValueTypes.StringValue.name]
+                result[key] = attr['Value'][ValueTypes.StringValue.name]
             elif ValueTypes.BinaryValue.name in attr['Value'].keys():
-                result[attr['Key']['Name']] = attr['Value'][ValueTypes.BinaryValue.name]
+                result[key] = attr['Value'][ValueTypes.BinaryValue.name]
             elif ValueTypes.BinaryValue.name in attr['Value'].keys():
-                result[attr['Key']['Name']] = attr['Value'][ValueTypes.BooleanValue.name]
+                result[key] = attr['Value'][ValueTypes.BooleanValue.name]
             elif ValueTypes.BinaryValue.name in attr['Value'].keys():
-                result[attr['Key']['Name']] = attr['Value'][ValueTypes.NumberValue.name]
+                result[key] = attr['Value'][ValueTypes.NumberValue.name]
             elif ValueTypes.BinaryValue.name in attr['Value'].keys():
-                result[attr['Key']['Name']] = attr['Value'][ValueTypes.DatetimeValue.name]
+                result[key] = attr['Value'][ValueTypes.DatetimeValue.name]
         return result
 
     def make_typed_link_specifier(

--- a/fusillade/directory/clouddirectory.py
+++ b/fusillade/directory/clouddirectory.py
@@ -83,7 +83,7 @@ class CloudDirectory:
     @retry(**cd_read_retry_parameters)
     def list_object_children_paged(self, object_ref: str,
                                    next_token: Optional[str] = None,
-                                   per_page=None, **kwargs) -> Tuple[dict, Optional[str]]:
+                                   per_page: Optional[int] = None, **kwargs) -> Tuple[dict, Optional[str]]:
         """
         a wrapper around CloudDirectory.Client.list_object_children with paging
 

--- a/fusillade/directory/resource.py
+++ b/fusillade/directory/resource.py
@@ -14,18 +14,21 @@ The owner policy is added to the resource type and is used to determine what act
 perform on a resource.
 """
 import json
+import logging
 import os
 from collections import defaultdict
 from typing import List, Dict, Any, Type, Union
 
+from dcplib.aws.clients import clouddirectory as cd_client
 from fusillade.config import proj_path, Config
-from fusillade.directory import CloudNode, cd_client, ConsistencyLevel, logger, \
-    UpdateObjectParams, ValueTypes, UpdateActions, User
-from fusillade.directory.principal import Principal
+from fusillade.directory.cloudnode import CloudNode
 from fusillade.directory.identifiers import get_obj_type_path
+from fusillade.directory.principal import Principal, User
+from fusillade.directory.structs import ConsistencyLevel, UpdateObjectParams, ValueTypes, UpdateActions
 from fusillade.errors import FusilladeHTTPException, FusilladeNotFoundException, FusilladeBadRequestException
 from fusillade.policy.validator import verify_policy
 
+logger = logging.getLogger(__name__)
 default_resource_owner_policy = os.path.join(proj_path, '..', 'policies', 'default_resource_owner_policy.json')
 
 

--- a/fusillade/directory/resource.py
+++ b/fusillade/directory/resource.py
@@ -408,7 +408,7 @@ class ResourceId(CloudNode):
                              object=dict(type=new_node.object_type, path_name=new_node._path_name)))
             return new_node
 
-    def add_principals(self, principals: List[Type['Principal']], access_level):
+    def add_principals(self, principals: List[Type['Principal']], access_level: str):
         """
         add a typed link from resource to principal with the access type.
         verifies that the policy exists before making link

--- a/fusillade/directory/resource.py
+++ b/fusillade/directory/resource.py
@@ -16,14 +16,14 @@ perform on a resource.
 import json
 import logging
 import os
-from collections import defaultdict
-from typing import List, Dict, Any, Type, Union
+from collections import defaultdict, deque
+from typing import List, Dict, Any, Type, Union, Tuple
 
 from dcplib.aws.clients import clouddirectory as cd_client
 from fusillade.config import proj_path, Config
 from fusillade.directory.cloudnode import CloudNode
 from fusillade.directory.identifiers import get_obj_type_path
-from fusillade.directory.principal import Principal, User
+from fusillade.directory.principal import Principal, User, Group
 from fusillade.directory.structs import ConsistencyLevel, UpdateObjectParams, ValueTypes, UpdateActions
 from fusillade.errors import FusilladeHTTPException, FusilladeNotFoundException, FusilladeBadRequestException
 from fusillade.policy.validator import verify_policy
@@ -408,6 +408,59 @@ class ResourceId(CloudNode):
                              object=dict(type=new_node.object_type, path_name=new_node._path_name)))
             return new_node
 
+    def list_principals(
+            self,
+            next_token: str = None,
+            per_page: int = None) -> Tuple[Dict[str, List[Dict[str, str]]], str]:
+        """
+        List the principals that have some level of  access to this resource id.
+
+        :param next_token:
+        :param per_page:
+        :return: JSON-formatted list of principals and a token for pagination
+        """
+        # retrieve the raw list of object references from cloud directory
+        _results, next_token = self.cd.list_incoming_typed_links(self.object_ref, [], 'access_link',
+                                                                 next_token=next_token, paged=True, per_page=per_page)
+        result = deque()
+        if _results:
+            ops = []
+            for r in _results:
+                # retrieve the principal attribute from the `r`, this will be returned in the response.
+                result.append({'member_type': self.cd.parse_attributes(r['IdentityAttributeValues'])['principal']})
+                # build the batch_read request list to retrieve the rest of the attributes for the response
+                # We need `access_level` from the typed link
+                ops.append(self.cd.batch_get_link_attributes(r, ['access_level']))
+                # and we need need `name` from the source object.
+                ops.append(self.cd.batch_get_attributes(
+                    r['SourceObjectReference']['Selector'],
+                    Principal._facet,
+                    ['name']))
+                # There are two requests per `r` in `_results`
+
+            # `switch` is used to retrieve the two responses per `r` in `_results`
+            switch = True
+            for resp in self.cd.batch_read(ops)['Responses']:
+                # Below, temp stores the result we are working on. Once we have retrieved both responses and added
+                # the relavent attributes to temp, we append back to the results. This is to sync the results with
+                # the batch read responses.
+                if resp.get('SuccessfulResponse'):
+                    if switch:
+                        temp = result.popleft()
+                        temp.update(self.cd.parse_attributes(
+                            resp['SuccessfulResponse']
+                            ['GetLinkAttributes']
+                            ['Attributes']))
+                        switch = False
+                    else:
+                        temp['member'] = self.cd.parse_attributes(
+                            resp['SuccessfulResponse']
+                            ['GetObjectAttributes']
+                            ['Attributes'])['name']
+                        result.append(temp)
+                        switch = True
+        return {'members': list(result)}, next_token
+
     def add_principals(self, principals: List[Type['Principal']], access_level: str):
         """
         add a typed link from resource to principal with the access type.
@@ -480,7 +533,56 @@ class ResourceId(CloudNode):
         except cd_client.exceptions.ResourceNotFoundException:
             raise FusilladeNotFoundException(f"Failed to delete {self.name}. {self.object_type} does not exist.")
 
+    def modify_principals(self, principals: List[Dict[str, str]]) -> None:
+        """
+        Modify a list of principals to grant them access to this resource id by adding, updating or deleting access
+        levels as needed.
+
+        :param principals: list of principals to grant access to this resource id
+        :return:
+        """
+        ops = []
+        modifications = []
+        for p in principals:
+            principal = User(p['member']) if p['member_type'] == 'user' else Group(p['member'])
+            modifications.append((principal, p.get('access_level')))
+            # tls is a pointer to the edge connecting a principal and resource.
+            tls = self.cd.make_typed_link_specifier(
+                principal.object_ref,
+                self.object_ref,
+                'access_link',
+                {'principal': principal.object_type,
+                 'resource': self.resource_type.name})
+            ops.append(self.cd.batch_get_link_attributes(tls, ['access_level']))
+
+        try:
+            for modifications, r in zip(modifications, self.cd.batch_read(ops)['Responses']):
+                if r.get('SuccessfulResponse'):
+                    current_ap = r['SuccessfulResponse']['GetLinkAttributes']['Attributes'][0]['Value'].popitem()[1]
+                    if modifications[1] == current_ap:  # Pass
+                        # If the old access level of the principal is equal to the new access level, then do nothing.
+                        continue
+                    elif modifications[1] is None:  # delete
+                        # If the access level field is missing, then remove access for the principal
+                        self.remove_principals([modifications[0]])
+                    elif modifications[1] != current_ap:  # update
+                        # If the new access level is not equal to the old access level then we update it to match.
+                        self.update_principal(*modifications)
+                else:
+                    # If the principal had no previous access level, then create a new access level edge in cloud
+                    # directory between the principal and the resource id
+                    self.add_principals([modifications[0]], modifications[1])
+
+        except cd_client.exceptions.ResourceNotFoundException:
+            return None
+
     def check_access(self, principals: List[Type['Principal']]) -> Union[None, List[str]]:
+        """
+        Given a list of principals, return a list of access levels to this resource id for each principal
+
+        :param principals:
+        :return: list of access levels to this resource id, one for each principal
+        """
         ops = []
         for principal in principals:
             tls = self.cd.make_typed_link_specifier(

--- a/fusillade/directory/resource.py
+++ b/fusillade/directory/resource.py
@@ -6,8 +6,8 @@ to apply access control logic (ACL).
 ### Actions
 This type of resource has certain action that can be performed on or with it, and these actions are store in an
 attribute called `actions`. Any access policy associated with this resource type must only include actions that the
-resource supports. This is checked before new policies are added, and nonconforming access policies are rejected. If an
-actions is removed from the resource type all existing access policies with this action will be removed.
+resource supports. This is checked before new policies are added, and nonconforming resource_policy are rejected. If an
+actions is removed from the resource type all existing resource_policy with this action will be removed.
 
 ### Owner policy
 The owner policy is added to the resource type and is used to determine what actions the owner of a resource Id can
@@ -135,7 +135,7 @@ class ResourceType(CloudNode):
                              ))
             return new_node
 
-    # TODO: Add function to modify actions, this will need to modify all access policies with this actions
+    # TODO: Add function to modify actions, this will need to modify all resource_policy with this actions
     @property
     def actions(self):
         if not self._actions:
@@ -167,7 +167,7 @@ class ResourceType(CloudNode):
                                             ' '.join(_actions),
                                             UpdateActions.CREATE_OR_UPDATE,
                                         )])
-        # TODO remove this actions from all access policies
+        # TODO remove this actions from all resource_policy
         self._actions = None
 
     def check_actions(self, policy: dict):
@@ -501,6 +501,6 @@ class ResourceId(CloudNode):
                 access_levels.add(self.resource_type.get_policy_path(attr[0]['Value'].popitem()[1]))
             return list(access_levels)
 
-    def get_access_policies(self, principals: List[Type['Principal']]):
-        access_policies = self.check_access(principals)
-        return self.cd.get_policies(access_policies)
+    def get_resource_policy(self, principals: List[Type['Principal']]):
+        resource_policy = self.check_access(principals)
+        return self.cd.get_policies(resource_policy)

--- a/fusillade/directory/resource.py
+++ b/fusillade/directory/resource.py
@@ -104,9 +104,7 @@ class ResourceType(CloudNode):
             ops.extend(new_node.create_policy('Owner',
                                               owner_policy,
                                               parent_path='#policy_node',
-                                              run=False,
-                                              type=new_node.object_type,
-                                              name=f"{new_node.name}:Owner"))
+                                              run=False))
 
         # Execute batch request
         try:
@@ -232,7 +230,8 @@ class ResourceType(CloudNode):
             self.check_actions(policy)
         verify_policy(policy, policy_type)
         operations = list()
-        object_attribute_list = self.cd.get_policy_attribute_list(policy_type, policy, **kwargs)
+        object_attribute_list = self.cd.get_policy_attribute_list(policy_type, policy, type=self.object_type,
+                                                                  name=policy_name, **kwargs)
         parent_path = parent_path or f"{self.object_ref}/policy"
         batch_reference = f'new_policy_{policy_name}'
         operations.append(
@@ -256,7 +255,9 @@ class ResourceType(CloudNode):
                     'BatchReferenceName': batch_reference
                 }
             }
+
         )
+
         if run:
             self.cd.batch_write(operations)
             logger.info(dict(message="Policy created",
@@ -333,10 +334,10 @@ class ResourceType(CloudNode):
             raise FusilladeNotFoundException(f"Failed to delete {self.name}. {self.object_type} does not exist.")
 
     def create_id(self, name: str, owner: str = None, **kwargs) -> 'ResourceId':
-        return ResourceId.create(self, name, owner, **kwargs)
+        return ResourceId.create(self.name, name, owner, **kwargs)
 
     def get_id(self, *args, **kwargs) -> 'ResourceId':
-        return ResourceId(self, *args, **kwargs)
+        return ResourceId(self.name, *args, **kwargs)
 
 
 class ResourceId(CloudNode):
@@ -345,8 +346,8 @@ class ResourceId(CloudNode):
     _facet: str = 'NodeFacet'
     allowed_policy_types = ['Resource']
 
-    def __init__(self, resource_type: ResourceType, *args, **kwargs):
-        self.resource_type: ResourceType = resource_type
+    def __init__(self, resource_type: str, *args, **kwargs):
+        self.resource_type: ResourceType = ResourceType(resource_type)
         super(ResourceId, self).__init__(*args, **kwargs)
         self._principals = None  # update roles
 
@@ -364,7 +365,7 @@ class ResourceId(CloudNode):
         return name
 
     @classmethod
-    def create(cls, resource_type: ResourceType, name: str, owner: str = None, **kwargs) -> 'ResourceId':
+    def create(cls, resource_type: str, name: str, owner: str = None, **kwargs) -> 'ResourceId':
         ops = []
         new_node = cls(resource_type, name=name)
         _owner = owner if owner else "fusillade"
@@ -464,16 +465,27 @@ class ResourceId(CloudNode):
         except cd_client.exceptions.ResourceNotFoundException:
             raise FusilladeNotFoundException(f"Failed to delete {self.name}. {self.object_type} does not exist.")
 
-    def check_access(self, principal: Type['Principal']) -> str:
-        tls = self.cd.make_typed_link_specifier(
-            principal.object_ref,
-            self.object_ref,
-            'access_link',
-            {'principal': principal.object_type,
-             'resource': self.resource_type.name})
+    def check_access(self, principals: List[Type['Principal']]) -> Union[None, List[str]]:
+        ops = []
+        for principal in principals:
+            tls = self.cd.make_typed_link_specifier(
+                principal.object_ref,
+                self.object_ref,
+                'access_link',
+                {'principal': principal.object_type,
+                 'resource': self.resource_type.name})
+            ops.append(self.cd.batch_get_link_attributes(tls, ['access_level']))
         try:
-            access_level = self.cd.get_link_attributes(tls, ['access_level'])['access_level']
+            attributes = [r['SuccessfulResponse']['GetLinkAttributes']['Attributes'] for r in self.cd.batch_read(ops)[
+                'Responses'] if r.get('SuccessfulResponse')]
         except cd_client.exceptions.ResourceNotFoundException:
             return None
         else:
-            return access_level
+            access_levels = set()
+            for attr in attributes:
+                access_levels.add(self.resource_type.get_policy_path(attr[0]['Value'].popitem()[1]))
+            return list(access_levels)
+
+    def get_access_policies(self, principals: List[Type['Principal']]):
+        access_policies = self.check_access(principals)
+        return self.cd.get_policies(access_policies)

--- a/fusillade/directory/resource.py
+++ b/fusillade/directory/resource.py
@@ -18,7 +18,7 @@ import os
 from collections import defaultdict
 from typing import List, Dict, Any, Type, Union
 
-from fusillade.config import proj_path
+from fusillade.config import proj_path, Config
 from fusillade.directory import CloudNode, cd_client, ConsistencyLevel, logger, \
     UpdateObjectParams, ValueTypes, UpdateActions, User
 from fusillade.directory.principal import Principal
@@ -35,6 +35,7 @@ class ResourceType(CloudNode):
     object_type: str = 'resource'
     _default_policy_path: str = default_resource_owner_policy
     policy_type = 'ResourcePolicy'
+    _resource_types: List[str] = None
 
     def __init__(self, *args, **kwargs):
         super(ResourceType, self).__init__(*args, **kwargs)
@@ -174,6 +175,13 @@ class ResourceType(CloudNode):
             policy_actions.update(s['Action'])
         if not policy_actions.issubset(set(self.actions)):
             raise FusilladeBadRequestException(detail="Invalid actions in policy.")
+
+    @classmethod
+    def get_types(cls):
+        if not cls._resource_types:
+            cd = Config.get_directory()
+            cls._resource_types = [name for name, _ in cd.list_object_children(f'/{cls.object_type}/')]
+        return cls._resource_types
 
     @staticmethod
     def hash_name(name):

--- a/fusillade/directory/resource.py
+++ b/fusillade/directory/resource.py
@@ -200,7 +200,12 @@ class ResourceType(CloudNode):
 
     def list_ids(self, next_token=None, per_page=None):
         children, next_token = self.cd.list_object_children_paged(f"{self.object_ref}/id", next_token, per_page)
-        return [f"/resource/{self.name}/id/{child}" for child in children.keys()], next_token
+        return (
+            {
+                'resource_ids': [f"/resource/{self.name}/id/{child}" for child in children.keys()],
+                'resource_type': self.name
+            },
+            next_token)
 
     def get_policy_reference(self, policy_name: str) -> str:
         """Returns a policy reference that can be used by cloud directory"""

--- a/fusillade/directory/resource.py
+++ b/fusillade/directory/resource.py
@@ -172,7 +172,8 @@ class ResourceType(CloudNode):
         for s in policy['Statement']:
             policy_actions.update(s['Action'])
         if not policy_actions.issubset(set(self.actions)):
-            raise FusilladeBadRequestException(detail="Invalid actions in policy.")
+            raise FusilladeBadRequestException(
+                detail=f"Invalid actions in policy. Allowed actions are {self.actions}")
 
     @classmethod
     def get_types(cls):

--- a/fusillade/directory/resource.py
+++ b/fusillade/directory/resource.py
@@ -191,12 +191,12 @@ class ResourceType(CloudNode):
         """
         return name
 
-    def list_policies(self, per_page=None, next=None):
-        children, next_token = self.cd.list_object_children_paged(f"{self.object_ref}/policy", next, per_page)
-        return [f"/resource/{self.name}/policy/{child}" for child in children.keys()], next_token
+    def list_policies(self, next_token=None, per_page=None) -> Dict[str, str]:
+        children, next_token = self.cd.list_object_children_paged(f"{self.object_ref}/policy", next_token, per_page)
+        return {'policies': [f"/resource/{self.name}/policy/{child}" for child in children.keys()]}, next_token
 
-    def list_ids(self, per_page=None, next=None):
-        children, next_token = self.cd.list_object_children_paged(f"{self.object_ref}/id", next, per_page)
+    def list_ids(self, next_token=None, per_page=None):
+        children, next_token = self.cd.list_object_children_paged(f"{self.object_ref}/id", next_token, per_page)
         return [f"/resource/{self.name}/id/{child}" for child in children.keys()], next_token
 
     def get_policy_reference(self, policy_name: str) -> str:
@@ -320,6 +320,7 @@ class ResourceType(CloudNode):
             attrs = dict([(attr['Key']['Name'], attr['Value'].popitem()[1]) for attr in resp['Attributes']])
         except cd_client.exceptions.ResourceNotFoundException:
             raise FusilladeNotFoundException(f"{self.get_policy_path(policy_name)} does not exist.")
+        attrs['policy_document'] = json.loads(attrs['policy_document'])
         return attrs
 
     def policy_exists(self, policy_name: str):

--- a/fusillade/directory/resource.py
+++ b/fusillade/directory/resource.py
@@ -340,6 +340,11 @@ class ResourceType(CloudNode):
     def get_id(self, *args, **kwargs) -> 'ResourceId':
         return ResourceId(self.name, *args, **kwargs)
 
+    def get_info(self) -> Dict[str, Any]:
+        info = super(ResourceType, self).get_info()
+        info[f'{self.object_type}_type'] = info.pop(f'{self.object_type}_id')
+        return info
+
 
 class ResourceId(CloudNode):
     """arn:*:resource/{resource_type}/{resource_id}"""

--- a/fusillade/directory_schema.json
+++ b/fusillade/directory_schema.json
@@ -128,9 +128,27 @@
           "attributeDefinition": {
             "attributeType": "STRING",
             "isImmutable": true,
-            "attributeRules": {}
+            "attributeRules": {
+            }
           },
           "requiredBehavior": "REQUIRED_ALWAYS"
+        },
+        "source": {
+          "attributeDefinition": {
+            "attributeType": "STRING",
+            "isImmutable": false,
+            "attributeRules": {
+            }
+          },
+          "requiredBehavior": "NOT_REQUIRED"
+        },
+        "target": {
+          "attributeDefinition": {
+            "attributeType": "STRING",
+            "isImmutable": false,
+            "attributeRules": {}
+          },
+          "requiredBehavior": "NOT_REQUIRED"
         }
       },
       "identityAttributeOrder": [
@@ -179,6 +197,14 @@
             "attributeRules": {}
           },
           "requiredBehavior": "REQUIRED_ALWAYS"
+        },
+        "access_level": {
+          "attributeDefinition": {
+            "attributeType": "STRING",
+            "isImmutable": false,
+            "attributeRules": {}
+          },
+          "requiredBehavior": "NOT_REQUIRED"
         }
       },
       "identityAttributeOrder": [

--- a/fusillade/errors.py
+++ b/fusillade/errors.py
@@ -20,6 +20,12 @@ class AuthorizationException(FusilladeException):
         self.reason = reason
 
 
+class ResourceNotFound(FusilladeException):
+    def __init__(self, reason, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.reason = reason
+
+
 class FusilladeHTTPException(ProblemException):
     pass
 
@@ -52,6 +58,7 @@ class FusilladeForbiddenException(FusilladeHTTPException):
                          title="Forbidden",
                          detail=detail,
                          *args, **kwargs)
+
 
 class FusilladeTooManyRequestsException(FusilladeHTTPException):
     def __init__(self, detail: str = "Rate limit reached. Try again in 30 seconds.",

--- a/fusillade/policy/resource_policy.py
+++ b/fusillade/policy/resource_policy.py
@@ -1,0 +1,9 @@
+import json
+from typing import List
+
+
+def combine(policies: List[str]) -> str:
+    statements = []
+    for p in policies:
+        statements.extend(json.loads(p)['Statement'])
+    return json.dumps(dict(Version="2012-10-17", Statement=statements))

--- a/fusillade/utils/authorize.py
+++ b/fusillade/utils/authorize.py
@@ -43,22 +43,22 @@ def evaluate_policy(
 ) -> Dict[str, Any]:
     context_entries = context_entries if context_entries else []
     eval_results = []
-    for _response in simulate_custom_policy_paginator.paginate(
-            PolicyInputList=[policy['policy'] for policy in policies],
-            ActionNames=actions,
-            ResourceArns=resources,
-            ContextEntries=[
-                {
-                    'ContextKeyName': 'fus:user_email',
-                    'ContextKeyValues': [principal],
-                    'ContextKeyType': 'string'
-                }, *context_entries
-            ],
-            PaginationConfig={
-                'MaxItems': 20,
-                'PageSize': 8
-            }
-    ):
+    params = dict(
+        PolicyInputList=[policy['policy'] for policy in policies],
+        ActionNames=actions,
+        ResourceArns=resources,
+        ContextEntries=[
+            {
+                'ContextKeyName': 'fus:user_email',
+                'ContextKeyValues': [principal],
+                'ContextKeyType': 'string'
+            }, *context_entries
+        ],
+        PaginationConfig={
+            'MaxItems': 20,
+            'PageSize': 8
+        })
+    for _response in simulate_custom_policy_paginator.paginate(**params):
         logger.info(_response['ResponseMetadata'])
         logger.debug(_response['EvaluationResults'])
         eval_results.extend(get_policy_statement(_response['EvaluationResults'], policies))

--- a/fusillade/utils/authorize.py
+++ b/fusillade/utils/authorize.py
@@ -14,7 +14,9 @@ iam = aws_clients.iam
 simulate_custom_policy_paginator = iam.get_paginator('simulate_custom_policy')
 
 
-def get_policy_statement(evaluation_results: List[Dict[str, Any]], policies: List[str]) -> List[Dict[str, Any]]:
+def get_policy_statement(evaluation_results: List[Dict[str, Any]],
+                         policies: List[Dict[str, Any]],
+                         resource_policy: str = None) -> List[Dict[str, Any]]:
     """
     Parses the response from simulate_custom_policy and adds the policy statements that matched to the results.
 
@@ -24,13 +26,25 @@ def get_policy_statement(evaluation_results: List[Dict[str, Any]], policies: Lis
     """
     for evaluation_result in evaluation_results:
         for ms in evaluation_result['MatchedStatements']:
-            policy_index = int(ms['SourcePolicyId'].split('.')[-1]) - 1
             begin = ms['StartPosition']['Column']
             end = ms['EndPosition']['Column']
-            policy = policies[policy_index]
-            ms['statement'] = policy['policy_document'][begin:end]
-            ms['SourcePolicyId'] = policy['name']
-            ms['SourcePolicyType'] = policy['type']
+            try:
+                policy_index = int(ms['SourcePolicyId'].split('.')[-1]) - 1
+            except ValueError:
+                if resource_policy:
+                    ms['Statement'] = resource_policy[begin:end]
+                    ms['SourcePolicyId'] = 'ResourcePolicy'
+                    ms['SourcePolicyType'] = 'ResourcePolicy'
+                else:
+                    logging.warning({"msg": "Failed to parse evaluation response.",
+                                     "MatchedStatements": ms,
+                                     "policies": policies,
+                                     "resource_policy": resource_policy})
+                    continue
+            else:
+                policy = policies[policy_index]
+                ms['SourcePolicyId'] = policy['name']
+                ms['SourcePolicyType'] = policy['type']
     return evaluation_results
 
 
@@ -39,6 +53,7 @@ def evaluate_policy(
         actions: List[str],
         resources: List[str],
         policies: List[Dict[str, str]],
+        resource_policy: str = None,
         context_entries: List[Dict] = None
 ) -> Dict[str, Any]:
     context_entries = context_entries if context_entries else []
@@ -57,11 +72,16 @@ def evaluate_policy(
         PaginationConfig={
             'MaxItems': 20,
             'PageSize': 8
-        })
+        }
+    )
+    if resource_policy:
+        params.update(
+            ResourcePolicy=resource_policy,
+            CallerArn='arn:aws:iam::634134578715:user/anyone')  # TODO this should be an AWS fusillade service account
     for _response in simulate_custom_policy_paginator.paginate(**params):
         logger.info(_response['ResponseMetadata'])
         logger.debug(_response['EvaluationResults'])
-        eval_results.extend(get_policy_statement(_response['EvaluationResults'], policies))
+        eval_results.extend(get_policy_statement(_response['EvaluationResults'], policies, resource_policy))
     eval_decisions = [er['EvalDecision'] for er in eval_results]
     if 'explicitDeny' in eval_decisions:
         response = {

--- a/fusillade/utils/json.py
+++ b/fusillade/utils/json.py
@@ -1,7 +1,15 @@
 import json
-from typing import Dict, Any
+from typing import Dict, Any, Union
 
 
 def get_json_file(file_name) -> Dict[str, Any]:
     with open(file_name, 'r') as fp:
         return json.load(fp)
+
+
+def json_equal(a: Union[dict, str], b: Union[dict, str]):
+    a = json.loads(a) if isinstance(a, str) else a
+    a = json.dumps(a, sort_keys=True)
+    b = json.loads(b) if isinstance(b, str) else b
+    b = json.dumps(b, sort_keys=True)
+    return a == b

--- a/tests/base_api_test.py
+++ b/tests/base_api_test.py
@@ -53,12 +53,14 @@ class BaseAPITest():
         cls.saved_groups = _iterator('/v1/groups', 'groups')
         cls.saved_users = _iterator('/v1/users', 'users')
         cls.saved_roles = _iterator('/v1/roles', 'roles')
+        cls.saved_resources = _iterator('/v1/resource', 'resources')
 
     @classmethod
     def clear_directory(cls, **kwargs):
         kwargs["users"] = kwargs.get('users', []) + [*Config.get_admin_emails()] + cls.saved_users
         kwargs["groups"] = kwargs.get('groups', []) + cls.saved_groups
         kwargs["roles"] = kwargs.get('roles', []) + cls.saved_roles
+        kwargs["resources"] = kwargs.get('resources', []) + cls.saved_resources
         clear_cd(Config.get_directory(), **kwargs)
 
     @classmethod

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,17 +1,17 @@
 import json
 import os
-import time
 import typing
 
 import jwt
-from dcplib.aws import clients
+import time
 
-from fusillade.directory import publish_schema, create_directory
+from dcplib.aws import clients
 from fusillade import CloudDirectory
 from fusillade.config import Config
+from fusillade.directory import publish_schema, create_directory
 from tests import schema_name, random_hex_string
 
-test_account_file=f"{os.environ['FUS_HOME']}/test_accounts_{os.environ['FUS_DEPLOYMENT_STAGE']}.json"
+test_account_file = f"{os.environ['FUS_HOME']}/test_accounts_{os.environ['FUS_DEPLOYMENT_STAGE']}.json"
 try:
     with open(test_account_file, 'r') as fh:
         service_accounts = json.load(fh)
@@ -34,16 +34,21 @@ def normalize_json(src: typing.Union[str, dict]):
     return json.dumps(src, sort_keys=True)
 
 
-def create_test_IAMPolicy(name: str, actions: typing.List[str] = None) -> dict:
+def create_test_IAMPolicy(name: str, actions: typing.List[str] = None,
+                          resource_type: str = 'project',
+                          effect='Deny'
+                          ) -> dict:
     """Assists with the creation of policy statements for testing"""
+    if effect not in ['Deny', 'Allow']:
+        effect = 'Deny'
     statement = {
         "Version": "2012-10-17",
         "Statement": [
             {
                 "Sid": "DefaultRole",
-                "Effect": "Deny",
+                "Effect": effect,
                 "Action": actions if actions else ["fake:action"],
-                "Resource": "fake:resource"
+                "Resource": f"arn:dcp:fus:us-east-1:dev:{resource_type}/*"
             }
         ]
     }
@@ -52,17 +57,21 @@ def create_test_IAMPolicy(name: str, actions: typing.List[str] = None) -> dict:
     return statement
 
 
-def create_test_ResourcePolicy(name: str, actions: typing.List[str] = None) -> dict:
+def create_test_ResourcePolicy(name: str, actions: typing.List[str] = None,
+                               resource_type: str = 'project',
+                               effect='Deny') -> dict:
     """Assists with the creation of policy statements for testing"""
+    if effect not in ['Deny', 'Allow']:
+        effect = 'Deny'
     statement = {
         "Version": "2012-10-17",
         "Statement": [
             {
                 "Principal": "*",
                 "Sid": "DefaultRole",
-                "Effect": "Deny",
+                "Effect": effect,
                 "Action": actions if actions else ["fake:action"],
-                "Resource": "arn:dcp:fus:us-east-1:dev:project/*"
+                "Resource": f"arn:dcp:fus:us-east-1:dev:{resource_type}/*"
             }
         ]
     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,72 +9,13 @@ import os
 import sys
 import unittest
 
-from furl import furl
-
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-from tests import eventually
 from tests.base_api_test import BaseAPITest
-from tests.common import get_auth_header, service_accounts
 
 
 class TestApi(BaseAPITest, unittest.TestCase):
-
-    def test_evaluate_policy(self):
-        email = "test_evaluate_api@email.com"
-        tests = [
-            {
-                'json_request_body': {
-                    "action": ["dss:CreateSubscription"],
-                    "resource": [f"arn:hca:dss:*:*:subscriptions/{email}/*"],
-                    "principal": "test@email.com"
-                },
-                'response': {
-                    'code': 200,
-                    'result': False
-                }
-            },
-            {
-                'json_request_body': {
-                    "action": ["fus:GetUser"],
-                    "resource": [f"arn:hca:fus:*:*:user/{email}/policy"],
-                    "principal": email
-                },
-                'response': {
-                    'code': 200,
-                    'result': True
-                }
-            }
-        ]
-        headers = {'Content-Type': "application/json"}
-        headers.update(get_auth_header(service_accounts['admin']))
-
-        @eventually(5, 0.5)
-        def _run_test(test):
-            data = json.dumps(test['json_request_body'])
-            resp = self.app.post('/v1/policies/evaluate', headers=headers, data=data)
-            self.assertEqual(test['response']['code'], resp.status_code, test['response'])
-            self.assertEqual(test['response']['result'], json.loads(resp.body)['result'], msg=json.loads(resp.body))
-
-        self._test_custom_claim(self.app.post,
-                                '/v1/policies/evaluate',
-                                headers,
-                                json.dumps(tests[1]['json_request_body']))
-
-        for test in tests:
-            with self.subTest(test['json_request_body']):
-                _run_test(test)
-
-        with self.subTest("User Disabled"):
-            resp = self.app.put(furl(f"/v1/user/{email}",
-                                     query_params={'user_id': email, 'status': 'disabled'}).url,
-                                headers=headers)
-            self.assertEqual(200, resp.status_code)
-            resp = self.app.post('/v1/policies/evaluate', headers=headers,
-                                 data=json.dumps(tests[1]['json_request_body']))
-            self.assertEqual(200, resp.status_code)
-            self.assertEqual(False, json.loads(resp.body)['result'], msg=json.loads(resp.body))
 
     def test_serve_swagger_ui(self):
         routes = ['/swagger.json', '/']

--- a/tests/test_clouddirectory.py
+++ b/tests/test_clouddirectory.py
@@ -6,9 +6,10 @@ from unittest.mock import patch
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
+from dcplib.aws.clients import clouddirectory as cd_client
 from tests.infra.testmode import standalone
 from tests.common import random_hex_string, service_accounts
-from fusillade.directory import cd_client, cleanup_directory, cleanup_schema, publish_schema, create_directory, \
+from fusillade.directory import cleanup_directory, cleanup_schema, publish_schema, create_directory, \
     CloudNode
 from fusillade import Config, CloudDirectory
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import unittest
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from fusillade.utils.json import json_equal
+from fusillade.directory.authorization import get_resource_authz_parameters
+
+from fusillade.directory import cleanup_directory, cleanup_schema, User, clear_cd
+from fusillade.errors import FusilladeForbiddenException
+from fusillade.directory.resource import ResourceType
+from tests.common import new_test_directory
+from tests.infra.testmode import standalone
+
+
+@standalone
+class TestEvaluate(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.directory, cls.schema_arn = new_test_directory()
+
+    @classmethod
+    def tearDownClass(cls):
+        cleanup_directory(cls.directory._dir_arn)
+        cleanup_schema(cls.schema_arn)
+
+    def tearDown(self):
+        clear_cd(self.directory)
+
+    def test_get_authz_params(self):
+        actions = ['test:readproject', 'test:writeproject', 'test:deleteproject']
+        arn_prefix = "arn:dcp:fus:us-east-1:dev:"
+        resource_type = 'test_type'
+        test_type = ResourceType.create(resource_type, actions)
+        access_level = 'Reader'
+        resource_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Principal": "*",
+                    "Sid": "project_reader",
+                    "Effect": "Allow",
+                    "Action": ['test:readproject'],
+                    "Resource": f"{arn_prefix}{resource_type}/*"
+                }
+            ]
+        }
+        test_type.create_policy(access_level, resource_policy, 'ResourcePolicy')
+        user = User.provision_user('test_user')
+        type_id = '1234455'
+        resource = f'{arn_prefix}{resource_type}/{type_id}'
+
+        with self.subTest("A user has no access when no access level set between user and resource"):
+            with self.assertRaises(FusilladeForbiddenException):
+                get_resource_authz_parameters(user.name, resource)
+
+        with self.subTest("No resource policy parameters are returned when the user tries to access a resource that "
+                          "does not use resource policies"):
+            params = get_resource_authz_parameters(user.name, f"{arn_prefix}non_acl_resource/1234")
+            self.assertFalse(params.get('ResourcePolicy'))
+            self.assertFalse(params.get('resources'))
+
+        with self.subTest("The resource policy for the access level assigned to the user is returned when a user "
+                          "is given access to a resource"):
+            test_id = test_type.create_id(type_id)
+            test_id.add_principals([user], access_level)
+            params = get_resource_authz_parameters(user.name, resource)
+            self.assertTrue(json_equal(params['ResourcePolicy'], resource_policy))
+            self.assertEqual(['Reader'], params['resources'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_evaluate_api.py
+++ b/tests/test_evaluate_api.py
@@ -1,0 +1,75 @@
+import json
+import os
+import sys
+import unittest
+
+from furl import furl
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from tests import eventually
+from tests.base_api_test import BaseAPITest
+from tests.common import get_auth_header, service_accounts
+
+
+class TestEvaluateApi(BaseAPITest, unittest.TestCase):
+
+    def test_evaluate_policy(self):
+        email = "test_evaluate_api@email.com"
+        tests = [
+            {
+                'json_request_body': {
+                    "action": ["dss:CreateSubscription"],
+                    "resource": [f"arn:hca:dss:*:*:subscriptions/{email}/*"],
+                    "principal": "test@email.com"
+                },
+                'response': {
+                    'code': 200,
+                    'result': False
+                }
+            },
+            {
+                'json_request_body': {
+                    "action": ["fus:GetUser"],
+                    "resource": [f"arn:hca:fus:*:*:user/{email}/policy"],
+                    "principal": email
+                },
+                'response': {
+                    'code': 200,
+                    'result': True
+                }
+            }
+        ]
+        headers = {'Content-Type': "application/json"}
+        headers.update(get_auth_header(service_accounts['admin']))
+
+        @eventually(5, 0.5)
+        def _run_test(test):
+            data = json.dumps(test['json_request_body'])
+            resp = self.app.post('/v1/policies/evaluate', headers=headers, data=data)
+            self.assertEqual(test['response']['code'], resp.status_code, test['response'])
+            self.assertEqual(test['response']['result'], json.loads(resp.body)['result'], msg=json.loads(resp.body))
+
+        self._test_custom_claim(self.app.post,
+                                '/v1/policies/evaluate',
+                                headers,
+                                json.dumps(tests[1]['json_request_body']))
+
+        for test in tests:
+            with self.subTest(test['json_request_body']):
+                _run_test(test)
+
+        with self.subTest("User Disabled"):
+            resp = self.app.put(furl(f"/v1/user/{email}",
+                                     query_params={'user_id': email, 'status': 'disabled'}).url,
+                                headers=headers)
+            self.assertEqual(200, resp.status_code)
+            resp = self.app.post('/v1/policies/evaluate', headers=headers,
+                                 data=json.dumps(tests[1]['json_request_body']))
+            self.assertEqual(200, resp.status_code)
+            self.assertEqual(False, json.loads(resp.body)['result'], msg=json.loads(resp.body))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_evaluate_api.py
+++ b/tests/test_evaluate_api.py
@@ -10,7 +10,10 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from tests import eventually
 from tests.base_api_test import BaseAPITest
-from tests.common import get_auth_header, service_accounts
+from tests.common import get_auth_header, service_accounts, create_test_ResourcePolicy, create_test_IAMPolicy
+
+admin_headers = {'Content-Type': "application/json"}
+admin_headers.update(get_auth_header(service_accounts['admin']))
 
 
 class TestEvaluateApi(BaseAPITest, unittest.TestCase):
@@ -70,6 +73,212 @@ class TestEvaluateApi(BaseAPITest, unittest.TestCase):
             self.assertEqual(200, resp.status_code)
             self.assertEqual(False, json.loads(resp.body)['result'], msg=json.loads(resp.body))
 
+    def test_evaluate_resource_policy(self):
+        resource_type = 'evaluate_test_type'
+        actions = sorted(['rt:read', 'rt:write', 'rt:delete'])
+        resource_id = 'protected-data'
+        arn_prefix = "arn:dcp:fus:us-east-1:dev:"
+        resource_arn = f'{arn_prefix}{resource_type}/{resource_id}'
+        user = 'user_test_access_levels'
+        group = 'user_default'
+
+        # create a resource type
+        resp = self.app.post(
+            f'/v1/resource/{resource_type}',
+            data=json.dumps({'actions': actions}),
+            headers=admin_headers)
+        self.assertEqual(resp.status_code, 201)
+
+        # create a resource policy read
+        resp = self.app.post(
+            f"/v1/resource/{resource_type}/policy/read",
+            data=json.dumps({'policy': create_test_ResourcePolicy(
+                'read',
+                actions=['rt:read'],
+                resource_type=resource_type,
+                effect='Allow'
+            )}),
+            headers=admin_headers
+        )
+        self.assertEqual(resp.status_code, 201)
+
+        # create a resource policy rw
+        resp = self.app.post(
+            f"/v1/resource/{resource_type}/policy/rw",
+            data=json.dumps({
+                'policy': create_test_ResourcePolicy(
+                    'rw',
+                    actions=['rt:read', 'rt:write', 'rt:delete'],
+                    resource_type=resource_type,
+                    effect='Allow'
+                )},
+            ),
+            headers=admin_headers
+        )
+        self.assertEqual(resp.status_code, 201)
+
+        # create a resource id
+        resp = self.app.post(
+            f'/v1/resource/{resource_type}/id/{resource_id}',
+            headers=admin_headers)
+        self.assertEqual(resp.status_code, 201)
+
+        # create a role with read
+        resp = self.app.post(
+            f'/v1/role',
+            data=json.dumps(
+                {'role_id': 'read',
+                 'policy': create_test_IAMPolicy(
+                     'read',
+                     actions=['rt:read'],
+                     resource_type=resource_type,
+                     effect='Allow'
+                 )}),
+            headers=admin_headers
+        )
+        self.assertEqual(resp.status_code, 201)
+
+        # create a role with rw
+        resp = self.app.post(
+            f'/v1/role',
+            data=json.dumps(
+                {'role_id': 'rw',
+                 'policy': create_test_IAMPolicy(
+                     'rw',
+                     actions=['rt:read', 'rt:write', 'rt:delete'],
+                     resource_type=resource_type,
+                     effect='Allow'
+                 )}),
+            headers=admin_headers
+        )
+        self.assertEqual(resp.status_code, 201)
+
+        # create a user
+        resp = self.app.post(
+            f'/v1/user',
+            data=json.dumps({'user_id': user}),
+            headers=admin_headers)
+        self.assertEqual(resp.status_code, 201)
+
+        # user fails to read resource
+        resp = self.app.post(
+            '/v1/policies/evaluate',
+            headers=admin_headers,
+            data=json.dumps(
+                {'principal': user,
+                 'action': ['rt:read'],
+                 'resource': [resource_arn]}
+            )
+        )
+        self.assertFalse(json.loads(resp.body)['result'])
+
+        # give the user role read
+        resp = self.app.put(
+            f'/v1/user/{user}/roles?action=add',
+            headers=admin_headers,
+            data=json.dumps(
+                {'roles': ['read']}
+            )
+
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        # user fails to read resource
+        resp = self.app.post(
+            '/v1/policies/evaluate',
+            headers=admin_headers,
+            data=json.dumps(
+                {'principal': user,
+                 'action': ['rt:read'],
+                 'resource': [resource_arn]}
+            )
+        )
+        self.assertFalse(json.loads(resp.body)['result'])
+
+        # give the user access level read
+        request_body = [
+            {'member': user,
+             'member_type': 'user',
+             'access_level': 'read'}
+        ]
+        resp = self.app.put(
+            f'/v1/resource/{resource_type}/id/{resource_id}/members',
+            data=json.dumps(request_body),
+            headers=admin_headers
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        # the user has read access to resource
+        resp = self.app.post(
+            '/v1/policies/evaluate',
+            headers=admin_headers,
+            data=json.dumps(
+                {'principal': user,
+                 'action': ['rt:read'],
+                 'resource': [resource_arn]}
+            )
+        )
+        self.assertTrue(json.loads(resp.body)['result'])
+
+        # the user does not have write access to resource
+        resp = self.app.post(
+            '/v1/policies/evaluate',
+            headers=admin_headers,
+            data=json.dumps(
+                {'principal': user,
+                 'action': ['rt:write'],
+                 'resource': [resource_arn]}
+            )
+        )
+        self.assertFalse(json.loads(resp.body)['result'])
+
+        # give the user_default group rw access to the resource
+        request_body = [
+            {'member': group,
+             'member_type': 'group',
+             'access_level': 'rw'}
+        ]
+        resp = self.app.put(
+            f'/v1/resource/{resource_type}/id/{resource_id}/members',
+            data=json.dumps(request_body),
+            headers=admin_headers
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        # the user does not have write access to resource
+        resp = self.app.post(
+            '/v1/policies/evaluate',
+            headers=admin_headers,
+            data=json.dumps(
+                {'principal': user,
+                 'action': ['rt:write'],
+                 'resource': [resource_arn]}
+            )
+        )
+        self.assertFalse(json.loads(resp.body)['result'])
+
+        # give the group role rw
+        resp = self.app.put(
+            f'/v1/group/{group}/roles?action=add',
+            headers=admin_headers,
+            data=json.dumps(
+                {'roles': ['rw']}
+            )
+
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        # the user does have write access to resource
+        resp = self.app.post(
+            '/v1/policies/evaluate',
+            headers=admin_headers,
+            data=json.dumps(
+                {'principal': user,
+                 'action': ['rt:write'],
+                 'resource': [resource_arn]}
+            )
+        )
+        self.assertTrue(json.loads(resp.body)['result'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -5,8 +5,9 @@ import unittest
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
+from dcplib.aws.clients import clouddirectory as cd_client
 from fusillade.errors import FusilladeHTTPException
-from fusillade.directory import User, Group, cd_client, cleanup_directory, cleanup_schema, \
+from fusillade.directory import User, Group, cleanup_directory, cleanup_schema, \
     Role, clear_cd
 from fusillade.directory.principal import default_group_policy_path
 from fusillade.utils.json import get_json_file

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -51,7 +51,7 @@ class TestGroup(unittest.TestCase, AssertJSONMixin):
     def test_policy(self):
         group = Group.create("new_group")
         with self.subTest("Only one policy is attached when lookup policy is called on a group without any roles"):
-            policies = [p['policy'] for p in group.get_authz_params()['policies']]
+            policies = [p['policy_document'] for p in group.get_authz_params()['IAMPolicy']]
             self.assertEqual(len(policies), 1)
             self.assertJSONEqual(policies[0], self.default_group_statement)
 
@@ -59,7 +59,7 @@ class TestGroup(unittest.TestCase, AssertJSONMixin):
         statement = create_test_IAMPolicy(group_name)
         with self.subTest("The group policy changes when satement is set"):
             group.set_policy(statement)
-            policies = [p['policy'] for p in group.get_authz_params()['policies']]
+            policies = [p['policy_document'] for p in group.get_authz_params()['IAMPolicy']]
             self.assertJSONEqual(policies[0], statement)
 
         with self.subTest("error raised when invalid statement assigned to group.get_policy()."):
@@ -109,7 +109,7 @@ class TestGroup(unittest.TestCase, AssertJSONMixin):
             group.add_roles(roles)
             self.assertEqual(len(group.roles), 2)
         with self.subTest("policies inherited from roles are returned when lookup policies is called"):
-            group_policies = sorted([normalize_json(p['policy']) for p in group.get_authz_params()['policies']])
+            group_policies = sorted([normalize_json(p['policy_document']) for p in group.get_authz_params()['IAMPolicy']])
             role_policies = sorted([normalize_json(role.get_policy()) for role in role_objs] + [
                 self.default_group_statement])
             self.assertListEqual(group_policies, role_policies)

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -50,7 +50,7 @@ class TestResourceType(unittest.TestCase):
         self.assertTrue(set(test_type.actions) == set(actions))
 
         # owner policy exists
-        self.assertIn(f'/resource/{resource_type}/policy/Owner', test_type.list_policies()[0])
+        self.assertIn(f'/resource/{resource_type}/policy/Owner', test_type.list_policies()[0]['policies'])
 
         # create an additional resource type
         resource_type2 = 'test_type2'
@@ -72,19 +72,19 @@ class TestResourceType(unittest.TestCase):
 
         # retrieve a specific access policy
         test_policy = test_type.get_policy('Reader')
-        self.assertDictEqual(expected_policy, json.loads(test_policy['policy_document']))
+        self.assertDictEqual(expected_policy, test_policy['policy_document'])
         self.assertEqual('ResourcePolicy', test_policy['policy_type'])
 
         # retrieve all policies
         policies, _ = test_type.list_policies()
-        self.assertIn(f'/resource/{resource_type}/policy/Reader', policies)
-        self.assertIn(f'/resource/{resource_type}/policy/Owner', policies)
+        self.assertIn(f'/resource/{resource_type}/policy/Reader', policies['policies'])
+        self.assertIn(f'/resource/{resource_type}/policy/Owner', policies['policies'])
 
         # update a policy
         expected_policy = create_test_ResourcePolicy("updated", actions[0:1])
         test_type.update_policy('Reader', expected_policy, 'ResourcePolicy')
         test_policy = test_type.get_policy('Reader')
-        self.assertDictEqual(expected_policy, json.loads(test_policy['policy_document']))
+        self.assertDictEqual(expected_policy, test_policy['policy_document'])
         self.assertEqual('ResourcePolicy', test_policy['policy_type'])
 
         # invalid actions raise an exception

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -52,6 +52,15 @@ class TestResourceType(unittest.TestCase):
         # owner policy exists
         self.assertIn(f'/resource/{resource_type}/policy/Owner', test_type.list_policies()[0])
 
+        # create an additional resource type
+        resource_type2 = 'test_type2'
+        self._create_resource_type(resource_type2, actions)
+        test_type2 = ResourceType(resource_type2)
+
+        # list resources
+        resource_types = ResourceType.get_types()
+        self.assertEqual([resource_type, resource_type2], resource_types)
+
     def test_access_policy(self):
         actions = ['readproject', 'writeproject', 'deleteproject']
         resource_type = 'test_type'

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -61,7 +61,7 @@ class TestResourceType(unittest.TestCase):
         resource_types = ResourceType.get_types()
         self.assertEqual([resource_type, resource_type2], resource_types)
 
-    def test_access_policy(self):
+    def test_resource_policy(self):
         actions = ['readproject', 'writeproject', 'deleteproject']
         resource_type = 'test_type'
         test_type = self._create_resource_type(resource_type, actions)
@@ -160,7 +160,7 @@ class TestResourceType(unittest.TestCase):
         self.assertEqual(test_id.check_access(users), [test_type.get_policy_path('Reader')])
 
         # get policies
-        policies = test_id.get_access_policies(users)
+        policies = test_id.get_resource_policy(users)
         self.assertTrue(test_type.get_policy('Reader'))
 
 

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -11,7 +11,7 @@ from fusillade.directory.principal import default_group_policy_path
 from fusillade.utils.json import get_json_file
 from fusillade.errors import FusilladeBadRequestException, FusilladeNotFoundException, FusilladeHTTPException
 from fusillade.directory.resource import ResourceType
-from tests.common import new_test_directory, create_test_IAMPolicy, create_test_ResourcePolicy
+from tests.common import new_test_directory, create_test_ResourcePolicy
 from tests.infra.testmode import standalone
 
 
@@ -140,19 +140,28 @@ class TestResourceType(unittest.TestCase):
         self.assertTrue(test_types)
 
         # give a user read access to the id
-        user = User('public')
-        test_id.add_principals([user], 'Reader')
-        self.assertEqual(test_id.check_access(user), 'Reader')
+        user = [User('public')]
+        test_id.add_principals(user, 'Reader')
+        self.assertEqual(test_id.check_access(user)[0], test_type.get_policy_path('Reader'))
 
         # update access
         test_type.create_policy('RW', create_test_ResourcePolicy("resource policy", ['readproject', 'writeproject']),
                                 'ResourcePolicy')
-        test_id.update_principal(user, 'RW')
-        self.assertEqual(test_id.check_access(user), 'RW')
+        test_id.update_principal(user[0], 'RW')
+        self.assertEqual(test_id.check_access(user)[0], test_type.get_policy_path('RW'))
 
         # remove access
-        test_id.remove_principals([user])
-        self.assertEqual(test_id.check_access(user), None)
+        test_id.remove_principals(user)
+        self.assertFalse(test_id.check_access(user))
+
+        # multiple principals
+        users = [User.provision_user(f'user{i}') for i in range(3)]
+        test_id.add_principals(users[:-1], 'Reader')
+        self.assertEqual(test_id.check_access(users), [test_type.get_policy_path('Reader')])
+
+        # get policies
+        policies = test_id.get_access_policies(users)
+        self.assertTrue(test_type.get_policy('Reader'))
 
 
 if __name__ == '__main__':

--- a/tests/test_resource_api.py
+++ b/tests/test_resource_api.py
@@ -272,8 +272,6 @@ class TestResourceIdApi(BaseAPITest, AssertJSONMixin, unittest.TestCase):
 
     def test_get_resource_ids(self):
         """Pages of resource ids are retrieved when using the get resource API"""
-        self.app.post(f'/v1/resource/{self.test_resource}', data=json.dumps({'actions': ['rt:get']}),
-                      headers=admin_headers)
         for i in range(11):
             self.app.post(f'/v1/resource/{self.test_resource}/id/test{i}', headers=admin_headers)
         self._test_paging(f'/v1/resource/{self.test_resource}/id', admin_headers, 10, 'resource_ids')
@@ -318,6 +316,154 @@ class TestResourceIdApi(BaseAPITest, AssertJSONMixin, unittest.TestCase):
             headers=admin_headers)
         self.assertEqual(resp.status_code, 404)
 
+    def test_get_member(self):
+        """Pages of resource ids are retrieved when using the get resource API"""
+        test_resource = 'test_get_member'
+        self.app.post(f'/v1/resource/{self.test_resource}/id/{test_resource}', headers=admin_headers)
+
+        # make groups
+        members = []
+        for group in [f'rt_group{i}' for i in range(5)]:
+            resp = self.app.post(
+                f'/v1/group',
+                data=json.dumps({'group_id': group}),
+                headers=admin_headers)
+            self.assertEqual(resp.status_code, 201)
+            members.append({'member': group,
+                            'member_type': 'group',
+                            'access_level': 'read'})
+
+        # make users
+        for user in [f'rt_user{i}' for i in range(6)]:
+            resp = self.app.post(
+                f'/v1/user',
+                data=json.dumps({'user_id': user}),
+                headers=admin_headers)
+            self.assertEqual(resp.status_code, 201)
+            members.append({'member': user,
+                            'member_type': 'user',
+                            'access_level': 'read'})
+        for m in members:
+            resp = self.app.put(
+                f'/v1/resource/{self.test_resource}/id/{test_resource}/members',
+                data=json.dumps([m]),
+                headers=admin_headers)
+            self.assertEqual(resp.status_code, 200)
+        self._test_paging(f'/v1/resource/{self.test_resource}/id/{test_resource}/members', admin_headers, 10, 'members')
+
+    def test_access_levels(self):
+        """Grant access to a principal for a resource"""
+        resource_id = 'protected-data'
+        arn_prefix = "arn:dcp:fus:us-east-1:dev:"
+        user = 'user_test_access_levels'
+        group = 'group_test_access_levels'
+
+        # create the resource to control
+        resp = self.app.post(
+            f'/v1/resource/{self.test_resource}/id/{resource_id}',
+            headers=admin_headers)
+        self.assertEqual(resp.status_code, 201)
+
+        with self.subTest("Check that no one has access by listing who has access"):
+            resp = self.app.get(
+                f'/v1/resource/{self.test_resource}/id/{resource_id}/members',
+                headers=admin_headers)
+            self.assertEqual(resp.status_code, 200)
+            self.assertJSONEqual(resp.body, {'members': []})
+
+        with self.subTest("Toggle user access."):
+            # create a user
+            resp = self.app.post(
+                f'/v1/user',
+                data=json.dumps({'user_id': user}),
+                headers=admin_headers)
+            self.assertEqual(resp.status_code, 201)
+
+            # give a user access
+            request_body = [
+                {'member': user,
+                 'member_type': 'user',
+                 'access_level': 'read'}
+            ]
+            resp = self.app.put(
+                f'/v1/resource/{self.test_resource}/id/{resource_id}/members',
+                data=json.dumps(request_body),
+                headers=admin_headers
+            )
+            self.assertEqual(resp.status_code, 200)
+
+            # Check that the user has access by listing who has access
+            resp = self.app.get(
+                f'/v1/resource/{self.test_resource}/id/{resource_id}/members',
+                headers=admin_headers)
+            self.assertEqual(resp.status_code, 200)
+            self.assertJSONEqual(resp.body, {'members': request_body})
+
+            # Remove access for the user
+            request_body = [
+                {'member': user,
+                 'member_type': 'user'}
+            ]
+            resp = self.app.put(
+                f'/v1/resource/{self.test_resource}/id/{resource_id}/members',
+                data=json.dumps(request_body),
+                headers=admin_headers
+            )
+            self.assertEqual(resp.status_code, 200)
+
+            # Check that the user does not have access by listing who has access
+            resp = self.app.get(
+                f'/v1/resource/{self.test_resource}/id/{resource_id}/members',
+                headers=admin_headers)
+            self.assertEqual(resp.status_code, 200)
+            self.assertJSONEqual(resp.body, {'members': []})
+
+        with self.subTest("Toggle group access."):
+            # create a group
+            resp = self.app.post(
+                f'/v1/group',
+                data=json.dumps({'group_id': group}),
+                headers=admin_headers)
+            self.assertEqual(resp.status_code, 201)
+
+            # give a group access
+            request_body = [
+                {'member': group,
+                 'member_type': 'group',
+                 'access_level': 'read'}
+            ]
+            resp = self.app.put(
+                f'/v1/resource/{self.test_resource}/id/{resource_id}/members',
+                data=json.dumps(request_body),
+                headers=admin_headers
+            )
+            self.assertEqual(resp.status_code, 200)
+
+            # Check that the group has access by listing who has access
+            resp = self.app.get(
+                f'/v1/resource/{self.test_resource}/id/{resource_id}/members',
+                headers=admin_headers)
+            self.assertEqual(resp.status_code, 200)
+            self.assertJSONEqual(resp.body, {'members': request_body})
+
+            # Remove access for the group
+            request_body = [
+                {'member': group,
+                 'member_type': 'group'}
+            ]
+            resp = self.app.put(
+                f'/v1/resource/{self.test_resource}/id/{resource_id}/members',
+                data=json.dumps(request_body),
+                headers=admin_headers
+            )
+            self.assertEqual(resp.status_code, 200)
+
+            # Check that the group does not have access by listing who has access
+            resp = self.app.get(
+                f'/v1/resource/{self.test_resource}/id/{resource_id}/members',
+                headers=admin_headers)
+            self.assertEqual(resp.status_code, 200)
+            self.assertJSONEqual(resp.body, {'members': []})
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_resource_api.py
+++ b/tests/test_resource_api.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+"""
+Functional Test of the Resource API
+"""
+import json
+import os
+import sys
+import unittest
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from tests.base_api_test import BaseAPITest
+from tests.common import get_auth_header, service_accounts
+
+admin_headers = {'Content-Type': "application/json"}
+admin_headers.update(get_auth_header(service_accounts['admin']))
+
+user_header = {'Content-Type': "application/json"}
+user_header.update(get_auth_header(service_accounts['user']))
+
+
+class TestApi(BaseAPITest, unittest.TestCase):
+
+    def test_create_resource(self):
+        """A resource type is created and destroyed using the API"""
+        test_resource = 'test_resource'  # the name of the resource type to create
+        resp = self.app.get(f'/v1/resource/{test_resource}', headers=admin_headers)
+        self.assertEqual(resp.status_code, 404)
+        resp = self.app.post(f'/v1/resource/{test_resource}', data=json.dumps({'actions': ['tr:action1']}),
+                             headers=admin_headers)
+        self.assertEqual(resp.status_code, 201)
+        resp = self.app.get(f'/v1/resource/{test_resource}', headers=admin_headers)
+        self.assertEqual(resp.status_code, 200)
+        resp = self.app.delete(f'/v1/resource/{test_resource}', headers=admin_headers)
+        self.assertEqual(resp.status_code, 200)
+        resp = self.app.get(f'/v1/resource/{test_resource}', headers=admin_headers)
+        self.assertEqual(resp.status_code, 404)
+
+    def test_access_resource(self):
+        """A user does not have access to a resource when they do not have permission."""
+        rt_name = 'thing'
+        role_name = 'test_role'
+        resp = self.app.post(f'/v1/resource/{rt_name}', data=json.dumps({'actions': ['tr:action1']}),
+                             headers=admin_headers)
+        self.assertEqual(resp.status_code, 201)
+        with self.subTest("Permission is denied"):
+            resp = self.app.get(f'/v1/resource/{rt_name}', headers=user_header)
+            self.assertEqual(resp.status_code, 403)
+
+        role_request_body = {
+            "role_id": role_name,
+            "policy": {
+                'Statement': [{
+                    'Sid': role_name,
+                    'Action': [
+                        "fus:DeleteResources",
+                        "fus:GetResources"],
+                    'Effect': 'Allow',
+                    'Resource': [f"arn:hca:fus:*:*:resource/{rt_name}"]
+                }]
+            }
+        }
+        resp = self.app.post(f'/v1/role', data=json.dumps(role_request_body), headers=admin_headers)
+        self.assertEqual(resp.status_code, 201)
+        resp = self.app.put(f"/v1/user/{service_accounts['user']['client_email']}/roles?action=add",
+                            data=json.dumps({'roles': [role_name]}),
+                            headers=admin_headers,)
+        self.assertEqual(resp.status_code, 200)
+
+        with self.subTest("Permission is granted"):
+            resp = self.app.get(f'/v1/resource/{rt_name}', headers=user_header)
+            self.assertEqual(resp.status_code, 200)
+
+    def test_get_resource(self):
+        """Pages of resource are retrieved when using the get resource API"""
+        for i in range(11):
+            self.app.post(f'/v1/resource/tr{i}', data=json.dumps({'actions': ['tr:action1']}), headers=admin_headers)
+        self._test_paging('/v1/resource', admin_headers, 10, 'resources')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_resource_api.py
+++ b/tests/test_resource_api.py
@@ -12,8 +12,9 @@ import unittest
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
+from tests.json_mixin import AssertJSONMixin
 from tests.base_api_test import BaseAPITest
-from tests.common import get_auth_header, service_accounts
+from tests.common import get_auth_header, service_accounts, create_test_ResourcePolicy
 
 admin_headers = {'Content-Type': "application/json"}
 admin_headers.update(get_auth_header(service_accounts['admin']))
@@ -22,7 +23,7 @@ user_header = {'Content-Type': "application/json"}
 user_header.update(get_auth_header(service_accounts['user']))
 
 
-class TestApi(BaseAPITest, unittest.TestCase):
+class TestApi(BaseAPITest, AssertJSONMixin, unittest.TestCase):
 
     def test_create_resource(self):
         """A resource type is created and destroyed using the API"""
@@ -67,7 +68,7 @@ class TestApi(BaseAPITest, unittest.TestCase):
         self.assertEqual(resp.status_code, 201)
         resp = self.app.put(f"/v1/user/{service_accounts['user']['client_email']}/roles?action=add",
                             data=json.dumps({'roles': [role_name]}),
-                            headers=admin_headers,)
+                            headers=admin_headers)
         self.assertEqual(resp.status_code, 200)
 
         with self.subTest("Permission is granted"):
@@ -79,6 +80,146 @@ class TestApi(BaseAPITest, unittest.TestCase):
         for i in range(11):
             self.app.post(f'/v1/resource/tr{i}', data=json.dumps({'actions': ['tr:action1']}), headers=admin_headers)
         self._test_paging('/v1/resource', admin_headers, 10, 'resources')
+
+    def test_get_resource_policy(self):
+        """Pages of resource are retrieved when using the get resource API"""
+        resp = self.app.post(f'/v1/resource/trp', data=json.dumps({'actions': ['trp:action1']}),
+                      headers=admin_headers)
+        self.assertEqual(resp.status_code, 201)
+        for i in range(11):
+            resp = self.app.post(f'/v1/resource/trp/policy/tp{i}',
+                          data=json.dumps({'policy':create_test_ResourcePolicy('tp{i}', actions=['trp:action1'])}),
+                          headers=admin_headers)
+            self.assertEqual(resp.status_code, 201)
+        self._test_paging('/v1/resource/trp/policy', admin_headers, 10, 'policies')
+
+    def test_resource_policy(self):
+        """Create delete and update a resource policy"""
+        expected_actions = sorted(['rt:get', 'rt:put', 'rt:update', 'rt:delete'])
+        test_resource = 'sample_resource'
+        test_policy_name = 'test_policy'
+        test_policy = create_test_ResourcePolicy('tp{i}', actions=expected_actions)
+        self.app.post(
+            f'/v1/resource/{test_resource}',
+            data=json.dumps({'actions': expected_actions}),
+            headers=admin_headers)
+
+        # 400 returned when creating a policy with invalid actions
+        test_policy = create_test_ResourcePolicy('tp{i}', actions=['invalid:actions'])
+        resp = self.app.post(
+            f"/v1/resource/{test_resource}/policy/{test_policy_name}",
+            data=json.dumps({'policy': test_policy}),
+            headers=admin_headers
+        )
+        self.assertEqual(resp.status_code, 400)
+        resp = self.app.get(
+            f"/v1/resource/{test_resource}/policy/{test_policy_name}",
+            headers=admin_headers
+        )
+        self.assertEqual(resp.status_code, 404)
+
+        # 201 return when creating a valid resource policy
+        test_policy = create_test_ResourcePolicy('tp{i}', actions=expected_actions)
+        resp = self.app.post(
+            f"/v1/resource/{test_resource}/policy/{test_policy_name}",
+            data=json.dumps({'policy': test_policy}),
+            headers=admin_headers
+        )
+        self.assertEqual(resp.status_code, 201)
+        resp = self.app.get(
+            f"/v1/resource/{test_resource}/policy/{test_policy_name}",
+            headers=admin_headers
+        )
+        self.assertJSONEqual(json.loads(resp.body)['policy_document'], test_policy)
+
+        # 200 returned when modifying the policy with valid actions
+        test_policy = create_test_ResourcePolicy('tp{i}', actions=expected_actions[:2])
+        resp = self.app.put(
+            f"/v1/resource/{test_resource}/policy/{test_policy_name}",
+            data=json.dumps({'policy': test_policy}),
+            headers=admin_headers
+        )
+        self.assertEqual(resp.status_code, 200)
+        resp = self.app.get(
+            f"/v1/resource/{test_resource}/policy/{test_policy_name}",
+            headers=admin_headers
+        )
+        self.assertJSONEqual(json.loads(resp.body)['policy_document'], test_policy)
+
+        # 400 returned when modifying the policy with invalid actions
+        test_policy2 = create_test_ResourcePolicy('tp{i}', actions=['invalid:actions'])
+        resp = self.app.put(
+            f"/v1/resource/{test_resource}/policy/{test_policy_name}",
+            data=json.dumps({'policy': test_policy2}),
+            headers=admin_headers
+        )
+        self.assertEqual(resp.status_code, 400)
+        resp = self.app.get(
+            f"/v1/resource/{test_resource}/policy/{test_policy_name}",
+            headers=admin_headers
+        )
+        self.assertJSONEqual(json.loads(resp.body)['policy_document'], test_policy)
+
+        # delete the policy
+        resp = self.app.delete(
+            f"/v1/resource/{test_resource}/policy/{test_policy_name}",
+            headers=admin_headers
+        )
+        self.assertEqual(resp.status_code, 200)
+        resp = self.app.get(
+            f"/v1/resource/{test_resource}/policy/{test_policy_name}",
+            headers=admin_headers
+        )
+        self.assertEqual(resp.status_code, 404)
+
+    def test_resource_actions(self):
+        """Add and remove actions from a resource type"""
+        test_resource = 'sample_resource'
+        expected_actions = sorted(['rt:get', 'rt:put', 'rt:update', 'rt:delete'])
+        self.app.post(
+            f'/v1/resource/{test_resource}',
+            data=json.dumps({'actions': expected_actions}),
+            headers=admin_headers)
+
+        # Get the actions for a resource type
+        resp = self.app.get(f'/v1/resource/{test_resource}/actions', headers=admin_headers)
+        self.assertEqual(resp.status_code, 200)
+        actions = json.loads(resp.body)['actions']
+        self.assertEqual(actions, expected_actions)
+
+        # Delete actions from a resource type
+        modify_actions = expected_actions[-2:]
+        resp = self.app.delete(f'/v1/resource/{test_resource}/actions',
+                               data=json.dumps({'actions': modify_actions}),
+                               headers=admin_headers)
+        self.assertEqual(resp.status_code, 200)
+        resp = self.app.get(f'/v1/resource/{test_resource}/actions',
+                            data=json.dumps({'actions': modify_actions}),
+                            headers=admin_headers)
+        actions = sorted(json.loads(resp.body)['actions'])
+        self.assertEqual(actions, expected_actions[:2])
+
+        # OK returned when deleting actions not part of a resource type
+        resp = self.app.delete(f'/v1/resource/{test_resource}/actions',
+                               data=json.dumps({'actions': modify_actions}),
+                               headers=admin_headers)
+
+        # Put actions into a resource type
+        resp = self.app.put(f'/v1/resource/{test_resource}/actions',
+                            data=json.dumps({'actions': modify_actions}),
+                            headers=admin_headers)
+        self.assertEqual(resp.status_code, 200)
+        resp = self.app.get(f'/v1/resource/{test_resource}/actions',
+                            data=json.dumps({'actions': modify_actions}),
+                            headers=admin_headers)
+        actions = sorted(json.loads(resp.body)['actions'])
+        self.assertEqual(actions, expected_actions)
+
+        # OK returned when putting actions already a part of a resource type.
+        resp = self.app.put(f'/v1/resource/{test_resource}/actions',
+                            data=json.dumps({'actions': modify_actions}),
+                            headers=admin_headers)
+        self.assertEqual(resp.status_code, 200)
 
 
 if __name__ == '__main__':

--- a/tests/test_resource_api.py
+++ b/tests/test_resource_api.py
@@ -23,32 +23,48 @@ user_header = {'Content-Type': "application/json"}
 user_header.update(get_auth_header(service_accounts['user']))
 
 
-class TestApi(BaseAPITest, AssertJSONMixin, unittest.TestCase):
+class TestResourceApi(BaseAPITest, AssertJSONMixin, unittest.TestCase):
+    rt_count = 0
+
+    @classmethod
+    def resource_type_name(cls):
+        cls.rt_count += 1
+        return f'sample_rt_{cls.rt_count}'
 
     def test_create_resource(self):
         """A resource type is created and destroyed using the API"""
-        test_resource = 'test_resource'  # the name of the resource type to create
+        test_resource = self.resource_type_name()  # the name of the resource type to create
+
+        # the resource type should not exist yet
         resp = self.app.get(f'/v1/resource/{test_resource}', headers=admin_headers)
         self.assertEqual(resp.status_code, 404)
+
+        # create the resource type
         resp = self.app.post(f'/v1/resource/{test_resource}', data=json.dumps({'actions': ['tr:action1']}),
                              headers=admin_headers)
         self.assertEqual(resp.status_code, 201)
+
+        # the resource type exists
         resp = self.app.get(f'/v1/resource/{test_resource}', headers=admin_headers)
         self.assertEqual(resp.status_code, 200)
+
+        # delete the resource type
         resp = self.app.delete(f'/v1/resource/{test_resource}', headers=admin_headers)
         self.assertEqual(resp.status_code, 200)
+
+        # the resource type should not exist
         resp = self.app.get(f'/v1/resource/{test_resource}', headers=admin_headers)
         self.assertEqual(resp.status_code, 404)
 
     def test_access_resource(self):
         """A user does not have access to a resource when they do not have permission."""
-        rt_name = 'thing'
+        test_resource = self.resource_type_name()
         role_name = 'test_role'
-        resp = self.app.post(f'/v1/resource/{rt_name}', data=json.dumps({'actions': ['tr:action1']}),
+        resp = self.app.post(f'/v1/resource/{test_resource}', data=json.dumps({'actions': ['tr:action1']}),
                              headers=admin_headers)
         self.assertEqual(resp.status_code, 201)
         with self.subTest("Permission is denied"):
-            resp = self.app.get(f'/v1/resource/{rt_name}', headers=user_header)
+            resp = self.app.get(f'/v1/resource/{test_resource}', headers=user_header)
             self.assertEqual(resp.status_code, 403)
 
         role_request_body = {
@@ -60,7 +76,7 @@ class TestApi(BaseAPITest, AssertJSONMixin, unittest.TestCase):
                         "fus:DeleteResources",
                         "fus:GetResources"],
                     'Effect': 'Allow',
-                    'Resource': [f"arn:hca:fus:*:*:resource/{rt_name}"]
+                    'Resource': [f"arn:hca:fus:*:*:resource/{test_resource}"]
                 }]
             }
         }
@@ -72,31 +88,34 @@ class TestApi(BaseAPITest, AssertJSONMixin, unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
 
         with self.subTest("Permission is granted"):
-            resp = self.app.get(f'/v1/resource/{rt_name}', headers=user_header)
+            resp = self.app.get(f'/v1/resource/{test_resource}', headers=user_header)
             self.assertEqual(resp.status_code, 200)
 
     def test_get_resource(self):
         """Pages of resource are retrieved when using the get resource API"""
         for i in range(11):
-            self.app.post(f'/v1/resource/tr{i}', data=json.dumps({'actions': ['tr:action1']}), headers=admin_headers)
+            self.app.post(f'/v1/resource/{self.resource_type_name()}', data=json.dumps({'actions': ['tr:action1']}),
+                          headers=admin_headers)
         self._test_paging('/v1/resource', admin_headers, 10, 'resources')
 
     def test_get_resource_policy(self):
         """Pages of resource are retrieved when using the get resource API"""
-        resp = self.app.post(f'/v1/resource/trp', data=json.dumps({'actions': ['trp:action1']}),
-                      headers=admin_headers)
+        test_resource = self.resource_type_name()
+        resp = self.app.post(f'/v1/resource/{test_resource}', data=json.dumps({'actions': ['trp:action1']}),
+                             headers=admin_headers)
         self.assertEqual(resp.status_code, 201)
         for i in range(11):
-            resp = self.app.post(f'/v1/resource/trp/policy/tp{i}',
-                          data=json.dumps({'policy':create_test_ResourcePolicy('tp{i}', actions=['trp:action1'])}),
-                          headers=admin_headers)
+            resp = self.app.post(f'/v1/resource/{test_resource}/policy/tp{i}',
+                                 data=json.dumps(
+                                     {'policy': create_test_ResourcePolicy('tp{i}', actions=['trp:action1'])}),
+                                 headers=admin_headers)
             self.assertEqual(resp.status_code, 201)
-        self._test_paging('/v1/resource/trp/policy', admin_headers, 10, 'policies')
+        self._test_paging(f'/v1/resource/{test_resource}/policy', admin_headers, 10, 'policies')
 
     def test_resource_policy(self):
         """Create delete and update a resource policy"""
         expected_actions = sorted(['rt:get', 'rt:put', 'rt:update', 'rt:delete'])
-        test_resource = 'sample_resource'
+        test_resource = self.resource_type_name()
         test_policy_name = 'test_policy'
         test_policy = create_test_ResourcePolicy('tp{i}', actions=expected_actions)
         self.app.post(
@@ -174,7 +193,7 @@ class TestApi(BaseAPITest, AssertJSONMixin, unittest.TestCase):
 
     def test_resource_actions(self):
         """Add and remove actions from a resource type"""
-        test_resource = 'sample_resource'
+        test_resource = self.resource_type_name()
         expected_actions = sorted(['rt:get', 'rt:put', 'rt:update', 'rt:delete'])
         self.app.post(
             f'/v1/resource/{test_resource}',

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -5,8 +5,9 @@ import unittest
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
+from dcplib.aws.clients import clouddirectory as cd_client
 from fusillade.errors import FusilladeHTTPException
-from fusillade.directory import User, Group, Role, cd_client, cleanup_directory, cleanup_schema, \
+from fusillade.directory import User, Group, Role, cleanup_directory, cleanup_schema, \
     get_json_file, default_user_policy_path, default_user_role_path, clear_cd
 from fusillade.directory.principal import default_group_policy_path
 from fusillade.utils.json import get_json_file

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -50,13 +50,13 @@ class TestUser(unittest.TestCase, AssertJSONMixin):
         user = User(name)
         with self.subTest("new user is automatically provisioned on demand with default settings when "
                           "lookup_policy is called for a new user."):
-            self.assertJSONListEqual([p['policy'] for p in user.get_authz_params()['policies']],
+            self.assertJSONListEqual([p['policy_document'] for p in user.get_authz_params()['IAMPolicy']],
                                      self.default_user_policies)
         with self.subTest("error is returned when provision_user is called for an existing user"):
             self.assertRaises(FusilladeHTTPException, user.provision_user, name)
         with self.subTest("an existing users info is retrieved when instantiating User class for an existing user"):
             user = User(name)
-            self.assertJSONListEqual([p['policy'] for p in user.get_authz_params()['policies']],
+            self.assertJSONListEqual([p['policy_document'] for p in user.get_authz_params()['IAMPolicy']],
                                      self.default_user_policies)
 
     def test_get_groups(self):
@@ -89,7 +89,7 @@ class TestUser(unittest.TestCase, AssertJSONMixin):
             self.assertEqual(len(user.groups), 6)
 
         with self.subTest("A user inherits the groups policies when joining a group"):
-            policies = set([normalize_json(p['policy']) for p in user.get_authz_params()['policies']])
+            policies = set([normalize_json(p['policy_document']) for p in user.get_authz_params()['IAMPolicy']])
             expected_policies = set([normalize_json(i[1]) for i in test_groups])
             expected_policies.update(self.default_user_policies)
             self.assertSetEqual(policies, expected_policies)
@@ -126,14 +126,14 @@ class TestUser(unittest.TestCase, AssertJSONMixin):
         with self.subTest("The user policy is set when statement setter is used."):
             expected_statement = statement
             self.assertJSONEqual(user.get_policy(), expected_statement)
-            self.assertJSONIn(expected_statement, [p['policy'] for p in user.get_authz_params()['policies']])
+            self.assertJSONIn(expected_statement, [p['policy_document'] for p in user.get_authz_params()['IAMPolicy']])
 
         statement = create_test_IAMPolicy(f"UserPolicySomethingElse2")
         user.set_policy(statement)
         with self.subTest("The user policy changes when set_policy is used."):
             expected_statement = statement
             self.assertJSONEqual(user.get_policy(), expected_statement)
-            self.assertJSONIn(expected_statement, [p['policy'] for p in user.get_authz_params()['policies']])
+            self.assertJSONIn(expected_statement, [p['policy_document'] for p in user.get_authz_params()['IAMPolicy']])
 
         with self.subTest("Error raised when setting policy to an invalid statement"):
             with self.assertRaises(FusilladeHTTPException):
@@ -184,7 +184,7 @@ class TestUser(unittest.TestCase, AssertJSONMixin):
 
         user.set_policy(self.default_policy)
         with self.subTest("A user inherits a roles policies when a role is added to a user."):
-            policies = [p['policy'] for p in user.get_authz_params()['policies']]
+            policies = [p['policy_document'] for p in user.get_authz_params()['IAMPolicy']]
             self.assertJSONListEqual(policies, [user.get_policy(), role_statement, *self.default_user_policies])
 
         with self.subTest("A role is removed from user when remove role is called."):
@@ -197,7 +197,7 @@ class TestUser(unittest.TestCase, AssertJSONMixin):
             self.assertEqual(sorted(user_role_names), role_names)
 
         with self.subTest("A user inherits multiple role policies when the user has multiple roles."):
-            policies = [p['policy'] for p in user.get_authz_params()['policies']]
+            policies = [p['policy_document'] for p in user.get_authz_params()['IAMPolicy']]
             self.assertJSONListEqual(policies, [user.get_policy(), *self.default_user_policies, *role_statements])
 
         with self.subTest("A user's roles are listed when a listing a users roles."):
@@ -236,7 +236,7 @@ class TestUser(unittest.TestCase, AssertJSONMixin):
         authz_params = user.get_authz_params()
         self.assertListEqual(sorted(authz_params['roles']), sorted(['default_user'] + role_names))
         self.assertListEqual(sorted(authz_params['groups']), sorted(['user_default'] + group_names))
-        self.assertJSONListEqual([p['policy'] for p in authz_params['policies']],
+        self.assertJSONListEqual([p['policy_document'] for p in authz_params['IAMPolicy']],
                                  [user.get_policy(), *self.default_user_policies] + group_statements + role_statements)
 
     def test_ownership(self):


### PR DESCRIPTION
This adds resource based access control to fusillade. Admins can now create a resource type, create resource policies for that resource type, add resource ids under that resource types, and assign users and groups access to resource ids. In order for a user to have access to a resource, they must have a role that grants access either through a group or directly, and the user must be given access to a resource. 

### Test plan
 Adding test cases for all new APIs

### Deployment instructions & migrations
- Upgrade the schema to the latest

### Release notes

- Adding endpoints to create resource types and resource ids
- Adding endpoints to manage resource policies attached to resource types
- Adding endpoints to give users access to controlled resources.
 
### **Rebase these changes onto master. Do not squash.**
