### PR TITLE
Setting audience in authorization request

### DIFF
--- a/environment
+++ b/environment
@@ -37,6 +37,7 @@ OPENID_PROVIDER=humancellatlas.auth0.com
 ACM_CERTIFICATE_IDENTIFIER="826dbdb8-2b23-4cc9-8fd6-73aa6fc658d7"
 FUS_TERRAFORM_BACKEND_BUCKET_TEMPLATE=terraform-tsmith
 FUS_ADMIN_EMAILS=test_email@domain.com
+FUS_AUDIENCE=https://dev.data.humancellatlas.org/
 DEBUG=1
 JSON_LOGS=False
 AWS_SDK_LOAD_CONFIG=1 # Needed for Terraform to correctly use AWS assumed roles

--- a/fusillade/api/oauth.py
+++ b/fusillade/api/oauth.py
@@ -37,10 +37,10 @@ def authorize():
     openid_provider = Config.get_openid_provider()
     query_params["openid_provider"] = openid_provider
     query_params['response_type'] = "code"
-    query_params['audience'] = Config.get_audience()
     client_id = query_params.get("client_id")
     client_id = client_id if client_id != 'None' else None
     if client_id:
+        query_params['audience'] = Config.get_audience()
         auth_params = query_params
     else:
         state = base64.b64encode(json.dumps(query_params).encode()).decode()

--- a/fusillade/api/oauth.py
+++ b/fusillade/api/oauth.py
@@ -37,6 +37,7 @@ def authorize():
     openid_provider = Config.get_openid_provider()
     query_params["openid_provider"] = openid_provider
     query_params['response_type'] = "code"
+    query_params['audience'] = Config.get_audience()
     client_id = query_params.get("client_id")
     client_id = client_id if client_id != 'None' else None
     if client_id:

--- a/fusillade/api/oauth.py
+++ b/fusillade/api/oauth.py
@@ -51,6 +51,7 @@ def authorize():
                            scope="openid email profile",
                            redirect_uri=oauth2_config[openid_provider]["redirect_uri"],
                            state=state,
+                           audience = Config.get_audience(),
                            prompt=query_params.get('prompt') if query_params.get('prompt') == 'none' else 'login')
 
     dest = furl(get_openid_config(openid_provider)["authorization_endpoint"], query_params=auth_params)

--- a/fusillade/api/oauth.py
+++ b/fusillade/api/oauth.py
@@ -51,7 +51,7 @@ def authorize():
                            scope="openid email profile",
                            redirect_uri=oauth2_config[openid_provider]["redirect_uri"],
                            state=state,
-                           audience = Config.get_audience(),
+                           audience=Config.get_audience(),
                            prompt=query_params.get('prompt') if query_params.get('prompt') == 'none' else 'login')
 
     dest = furl(get_openid_config(openid_provider)["authorization_endpoint"], query_params=auth_params)

--- a/fusillade/config.py
+++ b/fusillade/config.py
@@ -8,8 +8,7 @@ class Config:
     _admin_emails: list = None
     _oauth2_config = None
     app = None
-    audience = ["https://dev.data.humancellatlas.org/",
-                "https://auth.data.humancellatlas.org/"]
+    audience = None
     _openid_provider = None
     version = "unversioned"
     directory_schema_version = {"Version": '0', "MinorVersion": '0'}
@@ -58,6 +57,8 @@ class Config:
 
     @classmethod
     def get_audience(cls):
+        if not cls.audience:
+            cls.audience = os.environ['FUS_AUDIENCE']
         return cls.audience
 
     @classmethod

--- a/tests/common.py
+++ b/tests/common.py
@@ -114,7 +114,7 @@ def get_service_jwt(service_credentials, email=True, audience=None):
     exp = iat + 3600
     payload = {'iss': service_credentials["client_email"],
                'sub': service_credentials["client_email"],
-               'aud': audience or Config.audience,
+               'aud': audience or Config.get_audience(),
                'iat': iat,
                'exp': exp,
                'scope': ['email', 'openid', 'offline_access'],


### PR DESCRIPTION
This fixes an issue were auth0 will use the default audience of dev, when it should be the production audience. By specifying the audience in the authorization request we can target the correct auth0 API.

Functional this means that the audience returned in the JWT for environments dev to staging will be https://dev.data.humancellatlas.org/, and the audience for prod will be https://data.humancellatlas.org/.

A new environment variable `FUS_AUDIENCE` was added to the lambdas to set the audience.