### PR TITLE
Fus-API: remove plurals from resource-policy body

### DIFF
--- a/fusillade-api.yml
+++ b/fusillade-api.yml
@@ -1522,7 +1522,7 @@ components:
       type: object
       nullable: true
       properties:
-        Statements:
+        Statement:
           type: array
           items:
             type: object
@@ -1532,7 +1532,7 @@ components:
               Effect:
                 type: string
                 enum: ['Allow', 'Deny']
-              Actions:
+              Action:
                 type: array
                 items:
                   $ref: '#/components/schemas/policy_action'


### PR DESCRIPTION
Modifies example policy to be closer to how AWS specifies its IAM JSON Policy Elements.
see:
https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html

Connected To: #386  